### PR TITLE
Task06 Раед Романов HSE

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,17 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+__kernel void bitonic(__global float *as, uint n, uint blockOrder, uint comparisonStep) {
+    size_t id = get_global_id(0);
+    bool compareGreater = id & (1 << blockOrder);
+    size_t compareBlockId = id / comparisonStep;
+    size_t idInCompareBlock = id % comparisonStep;
+    size_t compareBlockStart = compareBlockId * comparisonStep * 2 + idInCompareBlock;
+    size_t i1 = compareBlockStart;
+    size_t i2 = compareBlockStart + comparisonStep;
+    if (i2 < n) {
+        bool cmp = as[i1] < as[i2];
+        if ((compareGreater && cmp) || (!compareGreater && !cmp)) {
+            float t = as[i1];
+            as[i1] = as[i2];
+            as[i2] = t;
+        }
+    }
 }

--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,11 +1,56 @@
-__kernel void bitonic(__global float *as, uint n, uint blockOrder, uint comparisonStep) {
+#define WORK_GROUP_SZ 256
+#define MAX_LOCAL_BLOCK_ORDER 8
+
+__kernel void bitonic_local(__global float *as, uint n) {
+    size_t id = get_global_id(0);
+    size_t lId = get_local_id(0);
+
+    __local float buf[WORK_GROUP_SZ * 2];
+    if (id < n) {
+        buf[lId] = as[(id - lId) * 2 + lId];
+    }
+    if (id + WORK_GROUP_SZ < n) {
+        buf[lId + WORK_GROUP_SZ] = as[(id - lId) * 2 + lId + WORK_GROUP_SZ];
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (size_t blockOrder = 0; blockOrder <= MAX_LOCAL_BLOCK_ORDER; ++blockOrder) {
+        for (size_t stepOrder = blockOrder + 1; stepOrder >= 1; --stepOrder) {
+            size_t comparisonBlockOrder = stepOrder - 1;
+            bool compareGreater = id & (1 << blockOrder);
+            size_t comparisonBlockMask = (((size_t) 1) << comparisonBlockOrder) - 1;
+            size_t compareBlockStart = ((lId & ~comparisonBlockMask) << 1) | (lId & comparisonBlockMask);
+            size_t i1 = compareBlockStart;
+            size_t i2 = compareBlockStart | (1 << comparisonBlockOrder);
+            if (i2 + (id - lId) * 2 < n) {
+                bool cmp = buf[i1] < buf[i2];
+                if ((compareGreater && cmp) || (!compareGreater && !cmp)) {
+                    float t = buf[i1];
+                    buf[i1] = buf[i2];
+                    buf[i2] = t;
+                }
+            }
+
+            barrier(CLK_LOCAL_MEM_FENCE);
+        }
+    }
+
+    if (id < n) {
+        as[(id - lId) * 2 + lId] = buf[lId];
+    }
+    if (id + WORK_GROUP_SZ < n) {
+        as[(id - lId) * 2 + lId + WORK_GROUP_SZ] = buf[lId + WORK_GROUP_SZ];
+    }
+}
+
+__kernel void bitonic(__global float *as, uint n, uint blockOrder, uint comparisonBlockOrder) {
     size_t id = get_global_id(0);
     bool compareGreater = id & (1 << blockOrder);
-    size_t compareBlockId = id / comparisonStep;
-    size_t idInCompareBlock = id % comparisonStep;
-    size_t compareBlockStart = compareBlockId * comparisonStep * 2 + idInCompareBlock;
+    size_t comparisonBlockMask = (((size_t)1) << comparisonBlockOrder) - 1;
+    size_t compareBlockStart = ((id & ~comparisonBlockMask) << 1) | (id & comparisonBlockMask);
     size_t i1 = compareBlockStart;
-    size_t i2 = compareBlockStart + comparisonStep;
+    size_t i2 = compareBlockStart | (1 << comparisonBlockOrder);
     if (i2 < n) {
         bool cmp = as[i1] < as[i2];
         if ((compareGreater && cmp) || (!compareGreater && !cmp)) {

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,20 @@
-// TODO
+__kernel void psum_fill_zero(__global uint* as, uint n) {
+    size_t id = get_global_id(0);
+    if (id < n) {
+        as[id] = 0;
+    }
+}
+
+__kernel void psum_reduce_adjacent(__global uint* in, __global uint* out, uint n) {
+    size_t id = get_global_id(0);
+    if (id * 2 < n) {
+        out[id] = in[id * 2] + ((id * 2 + 1 < n) ? in[id * 2 + 1] : 0);
+    }
+}
+
+__kernel void psum_reduce(__global uint* as, __global uint* bs, uint n, uint step) {
+    size_t id = get_global_id(0);
+    if (id < n && ((id + 1) & ((size_t)1 << step))) {
+        bs[id] += as[((id + 1) >> step) - 1];
+    }
+}

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -19,11 +19,36 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
+template <class T>
+std::ostream& operator <<(std::ostream& s, const std::vector<T>& data) {
+    for (const T& x : data) {
+        s << x << ' ';
+    }
+    return s;
+}
 
 int main(int argc, char **argv)
 {
 	int benchmarkingIters = 10;
 	unsigned int max_n = (1 << 24);
+
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
+    gpu::gpu_mem_32u as_gpu, bs_gpu, cs_gpu;
+    as_gpu.resizeN(max_n);
+    bs_gpu.resizeN(max_n);
+    cs_gpu.resizeN(max_n);
+
+    ocl::Kernel kernelReduceAdjacent(prefix_sum_kernel, prefix_sum_kernel_length, "psum_reduce_adjacent");
+    kernelReduceAdjacent.compile();
+    ocl::Kernel kernelReduce(prefix_sum_kernel, prefix_sum_kernel_length, "psum_reduce");
+    kernelReduce.compile();
+    ocl::Kernel kernelFillZero(prefix_sum_kernel, prefix_sum_kernel_length, "psum_fill_zero");
+    kernelFillZero.compile();
 
 	for (unsigned int n = 2; n <= max_n; n *= 2) {
 		std::cout << "______________________________________________" << std::endl;
@@ -77,7 +102,42 @@ int main(int argc, char **argv)
 		}
 
 		{
-			// TODO: implement on OpenCL
+            size_t workGroupSize = 128;
+            size_t workSize = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+            gpu::WorkSize ws(workGroupSize, workSize);
+
+            timer t;
+            for (size_t i = 0; i < benchmarkingIters; ++i) {
+                as_gpu.writeN(as.data(), n);
+
+                t.restart();
+
+                for (uint32_t step = 0; (1 << step) < 2 * n; ++step) {
+                    if (step) {
+                        uint32_t m = n >> (step - 1);
+                        size_t reduceAdjacentWorkSize =
+                                ((m + 1) / 2 + workGroupSize - 1) / workGroupSize * workGroupSize;
+                        kernelReduceAdjacent.exec(gpu::WorkSize(workGroupSize, reduceAdjacentWorkSize),
+                                                  as_gpu, cs_gpu, m);
+                        std::swap(as_gpu, cs_gpu);
+                    } else {
+                        kernelFillZero.exec(ws, bs_gpu, n);
+                    }
+                    kernelReduce.exec(ws, as_gpu, bs_gpu, n, step);
+                }
+
+                t.nextLap();
+            }
+
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+
+            std::vector<unsigned int> result(n);
+            bs_gpu.readN(result.data(), n);
+
+            for (int i = 0; i < n; ++i) {
+                EXPECT_THE_SAME(reference_result[i], result[i], "GPU result should be consistent!");
+            }
 		}
 	}
 }


### PR DESCRIPTION
Bitonic Sort

```
OpenCL devices:
  Device #0: GPU. Intel(R) UHD Graphics 620 [0x5917]. Total memory: 12714 Mb
  Device #1: GPU. NVIDIA GeForce MX150. Total memory: 2002 Mb
Using device #1: GPU. NVIDIA GeForce MX150. Total memory: 2002 Mb
Data generated for n=33554432!
CPU: 3.68584+-0.141309 s
CPU: 8.95318 millions/s
GPU: 1.79536+-0.000114906 s
GPU: 18.3807 millions/s
```

Prefix Sum

```
OpenCL devices:
  Device #0: GPU. Intel(R) UHD Graphics 620 [0x5917]. Total memory: 12714 Mb
  Device #1: GPU. NVIDIA GeForce MX150. Total memory: 2002 Mb
Using device #1: GPU. NVIDIA GeForce MX150. Total memory: 2002 Mb
______________________________________________
n=2 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 4.58333e-05+-8.97527e-07 s
GPU: 0.0436364 millions/s
______________________________________________
n=4 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 6.91667e-05+-3.72678e-07 s
GPU: 0.0578313 millions/s
______________________________________________
n=8 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 9.48333e-05+-6.87184e-07 s
GPU: 0.0843585 millions/s
______________________________________________
n=16 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000119167+-1.21335e-06 s
GPU: 0.134266 millions/s
______________________________________________
n=32 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000148833+-8.97527e-07 s
GPU: 0.215006 millions/s
______________________________________________
n=64 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.0001735+-1.89297e-06 s
GPU: 0.368876 millions/s
______________________________________________
n=128 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000196167+-1.77169e-06 s
GPU: 0.652506 millions/s
______________________________________________
n=256 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000219333+-7.45356e-07 s
GPU: 1.16717 millions/s
______________________________________________
n=512 values in range: [0; 1023]
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 3072 millions/s
GPU: 0.000241833+-1.95078e-06 s
GPU: 2.11716 millions/s
______________________________________________
n=1024 values in range: [0; 1023]
CPU: 1e-06+-0 s
CPU: 1024 millions/s
GPU: 0.0002685+-1.11803e-06 s
GPU: 3.81378 millions/s
______________________________________________
n=2048 values in range: [0; 1023]
CPU: 2e-06+-0 s
CPU: 1024 millions/s
GPU: 0.000293833+-2.11476e-06 s
GPU: 6.96994 millions/s
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 4e-06+-0 s
CPU: 1024 millions/s
GPU: 0.000313333+-1.05778e-05 s
GPU: 13.0723 millions/s
______________________________________________
n=8192 values in range: [0; 1023]
CPU: 6.83333e-06+-3.72678e-07 s
CPU: 1198.83 millions/s
GPU: 0.000331167+-5.8713e-06 s
GPU: 24.7368 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 1.4e-05+-0 s
CPU: 1170.29 millions/s
GPU: 0.0003215+-1.14419e-05 s
GPU: 50.9611 millions/s
______________________________________________
n=32768 values in range: [0; 1023]
CPU: 2.98333e-05+-3.72678e-07 s
CPU: 1098.37 millions/s
GPU: 0.000431167+-3.23608e-06 s
GPU: 75.9985 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 6.21667e-05+-3.72678e-07 s
CPU: 1054.2 millions/s
GPU: 0.000530833+-6.56802e-06 s
GPU: 123.459 millions/s
______________________________________________
n=131072 values in range: [0; 1023]
CPU: 0.000139833+-6.87184e-07 s
CPU: 937.344 millions/s
GPU: 0.000853667+-5.02217e-06 s
GPU: 153.54 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000339833+-4.0586e-06 s
CPU: 771.39 millions/s
GPU: 0.00143683+-5.33594e-06 s
GPU: 182.446 millions/s
______________________________________________
n=524288 values in range: [0; 1023]
CPU: 0.000655667+-6.87184e-06 s
CPU: 799.626 millions/s
GPU: 0.00248583+-2.66609e-05 s
GPU: 210.91 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0008535+-7.29492e-05 s
CPU: 1228.56 millions/s
GPU: 0.00462183+-4.7136e-05 s
GPU: 226.874 millions/s
______________________________________________
n=2097152 values in range: [0; 1023]
CPU: 0.00190383+-8.16321e-05 s
CPU: 1101.54 millions/s
GPU: 0.00874417+-1.01064e-05 s
GPU: 239.834 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00366517+-5.13109e-05 s
CPU: 1144.37 millions/s
GPU: 0.0173885+-7.32388e-05 s
GPU: 241.211 millions/s
______________________________________________
n=8388608 values in range: [0; 255]
CPU: 0.00831317+-0.000213273 s
CPU: 1009.07 millions/s
GPU: 0.0350072+-8.45412e-06 s
GPU: 239.625 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.015893+-0.00016192 s
CPU: 1055.64 millions/s
GPU: 0.0718543+-2.36549e-05 s
GPU: 233.489 millions/s
```