### PR TITLE
Task06 Рустам Садыков SPbU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,5 +32,5 @@ add_executable(prefix_sum src/main_prefix_sum.cpp src/cl/prefix_sum_cl.h)
 target_link_libraries(prefix_sum libclew libgpu libutils)
 
 convertIntoHeader(src/cl/radix.cl src/cl/radix_cl.h radix_kernel)
-add_executable(radix src/main_radix.cpp src/cl/radix_cl.h)
+add_executable(radix src/main_radix.cpp src/cl/radix_cl.h src/cl/prefix_sum_cl.h)
 target_link_libraries(radix libclew libgpu libutils)

--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,77 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+#ifdef __CLION_IDE__
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+
+#endif
+
+#line 6
+
+#ifndef WORK_GROUP_SIZE
+#define WORK_GROUP_SIZE 128
+#endif
+
+__kernel void bitonic(
+    __global float *as,
+    const unsigned int sorted_block_size,
+    const unsigned int step
+) {
+    const unsigned int global_id = get_global_id(0);
+
+    const unsigned int shift = sorted_block_size >> step;
+    const unsigned int block = global_id / shift;
+    const unsigned int pos = global_id + block * shift;
+
+    const unsigned int color_block = global_id / sorted_block_size;
+    const int sign = 1 - 2 * (color_block % 2);
+
+    float fst = as[pos];
+    float snd = as[pos + shift];
+
+    if (sign * fst > sign * snd) {
+        as[pos] = snd;
+        as[pos + shift] = fst;
+    }
+}
+
+__kernel void bitonic_local(
+    __global float *as,
+    const unsigned int sorted_block_size
+) {
+    const unsigned int global_id = get_global_id(0);
+    const unsigned int local_id = get_local_id(0);
+    const unsigned int group_id = get_group_id(0);
+
+    const unsigned int upload_shift = group_id * WORK_GROUP_SIZE;
+
+    __local float uploaded[2 * WORK_GROUP_SIZE];
+
+    uploaded[local_id] = as[global_id + upload_shift];
+    uploaded[local_id + WORK_GROUP_SIZE] = as[global_id + WORK_GROUP_SIZE + upload_shift];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    {
+        const unsigned int color_block = global_id / sorted_block_size;
+        const int sign = 1 - 2 * (color_block % 2);
+
+        for (unsigned int shift = sorted_block_size; shift > 0; shift >>= 1) {
+            const unsigned int block = local_id / shift;
+            const unsigned int pos = local_id + block * shift;
+
+            float fst = uploaded[pos];
+            float snd = uploaded[pos + shift];
+
+            if (sign * fst > sign * snd) {
+                uploaded[pos] = snd;
+                uploaded[pos + shift] = fst;
+            }
+
+            barrier(CLK_LOCAL_MEM_FENCE);
+        }
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    as[global_id + upload_shift] = uploaded[local_id];
+    as[global_id + WORK_GROUP_SIZE + upload_shift] = uploaded[local_id + WORK_GROUP_SIZE];
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,54 @@
-// TODO
+#ifdef __CLION_IDE__
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+
+#endif
+
+#line 6
+
+__kernel void init(
+    __global unsigned int *as,
+    unsigned int n
+) {
+    unsigned int i = get_global_id(0);
+    if (i < n) {
+        as[i] = 0;
+    }
+}
+
+__kernel void update(
+    __global unsigned int *as,
+    __global unsigned int *bs,
+    unsigned int n,
+    unsigned int bit
+) {
+    unsigned int i = get_global_id(0);
+    if (i >= n) {
+        return;
+    }
+    unsigned int id = i + 1;
+
+    if ((id >> bit) & 1) {
+        bs[i] += as[(id >> bit) - 1];
+    }
+}
+
+__kernel void reduce(
+    __global unsigned int *as,
+    __global unsigned int *bs,
+    unsigned int n
+) {
+    unsigned int i = get_global_id(0);
+    if (i >= n) {
+        return;
+    }
+    bs[i] = 0;
+    if (i * 2 >= n) {
+        return;
+    }
+    bs[i] += as[i * 2];
+    if (i * 2 + 1 >= n) {
+        return;
+    }
+    bs[i] += as[i * 2 + 1];
+}

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -1,3 +1,107 @@
-__kernel void radix(__global unsigned int *as) {
-    // TODO
+#ifdef __CLION_IDE__
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+
+#endif
+
+#line 6
+
+#ifndef WORK_GROUP_SIZE
+#define WORK_GROUP_SIZE 128
+#endif
+
+#ifndef BATCH_SIZE
+#define BATCH_SIZE 4
+#endif
+
+#define BATCH_COUNT (1 << BATCH_SIZE)
+#define MASK (BATCH_COUNT - 1)
+
+#define get_type(x, bit) ((x >> bit) & MASK)
+
+#define get_groups(x) ((x + WORK_GROUP_SIZE - 1) / WORK_GROUP_SIZE)
+
+__kernel void count(
+    __global unsigned int *as,
+    __global unsigned int *hist,
+    unsigned int n,
+    unsigned int bit
+) {
+    const unsigned int global_id = get_global_id(0);
+    const unsigned int local_id = get_local_id(0);
+    const unsigned int group_id = get_group_id(0);
+    const unsigned int groups = get_groups(n);
+
+    __local unsigned int local_hist[BATCH_COUNT * WORK_GROUP_SIZE];
+    for (unsigned int i = 0; i < BATCH_COUNT; ++i) {
+        local_hist[i * WORK_GROUP_SIZE + local_id] = 0;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (global_id < n) {
+        unsigned int type = get_type(as[global_id], bit);
+        local_hist[local_id * BATCH_COUNT + type] = 1;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_id < BATCH_COUNT) {
+        unsigned int sum = 0;
+        for (unsigned int i = 0; i < WORK_GROUP_SIZE; ++i) {
+            sum += local_hist[i * BATCH_COUNT + local_id];
+        }
+
+        hist[local_id * groups + group_id] = sum;
+    }
+
+}
+
+__kernel void radix(
+    __global unsigned int *as,
+    __global unsigned int *bs,
+    unsigned int n,
+    __global unsigned int *hist,
+    unsigned int bit
+) {
+    const unsigned int global_id = get_global_id(0);
+    const unsigned int local_id = get_local_id(0);
+    const unsigned int group_id = get_group_id(0);
+    const unsigned int groups = get_groups(n);
+
+    __local unsigned int uploaded[WORK_GROUP_SIZE];
+    __local unsigned int local_hist[BATCH_COUNT * WORK_GROUP_SIZE];
+
+    for (unsigned int i = 0; i < BATCH_COUNT; ++i) {
+        local_hist[i * WORK_GROUP_SIZE + local_id] = 0;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (global_id < n) {
+        unsigned int x = as[global_id];
+        unsigned int type = get_type(x, bit);
+        uploaded[local_id] = x;
+        local_hist[type * WORK_GROUP_SIZE + local_id] = 1;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_id < BATCH_COUNT) {
+        unsigned int sum = 0;
+        for (int i = 0; i < WORK_GROUP_SIZE; ++i) {
+            unsigned int idx = local_id * WORK_GROUP_SIZE + i;
+            unsigned int tmp = local_hist[idx];
+            local_hist[idx] = sum;
+            sum += tmp;
+        }
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (global_id < n) {
+        unsigned int x = uploaded[local_id];
+        unsigned int type = get_type(x, bit);
+        unsigned int hist_idx = type * groups + group_id;
+        unsigned int new_idx = (hist_idx == 0 ? 0 : hist[hist_idx - 1]) + local_hist[type * WORK_GROUP_SIZE + local_id];
+        bs[new_idx] = x;
+    }
+
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -50,13 +50,18 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
     {
-        ocl::Kernel bitonic(bitonic_kernel, bitonic_kernel_length, "bitonic");
+        unsigned int workGroupSize = 128;
+        std::string defines = " -D WORK_GROUP_SIZE=" + to_string(workGroupSize);
+        ocl::Kernel bitonic(bitonic_kernel, bitonic_kernel_length, "bitonic", defines);
         bitonic.compile();
+
+        ocl::Kernel bitonic_local(bitonic_kernel, bitonic_kernel_length, "bitonic_local", defines);
+        bitonic_local.compile();
 
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
@@ -64,9 +69,17 @@ int main(int argc, char **argv) {
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            unsigned int workGroupSize = 128;
-            unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
-            bitonic.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, n);
+            unsigned int global_work_size = n >> 1; // предполагаю, что размер это степень двойки и больше размера ворк-группы
+            unsigned int steps = 1;
+            for (unsigned int sorted_block_size = 1; sorted_block_size < n; sorted_block_size <<= 1, ++steps) {
+                if (sorted_block_size <= workGroupSize) {
+                    bitonic_local.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, sorted_block_size);
+                } else {
+                    for (unsigned int step = 0; step < steps; ++step) {
+                        bitonic.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, sorted_block_size, step);
+                    }
+                }
+            }
             t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
@@ -79,6 +92,6 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -6,6 +6,7 @@
 
 // Этот файл будет сгенерирован автоматически в момент сборки - см. convertIntoHeader в CMakeLists.txt:18
 #include "cl/radix_cl.h"
+#include "cl/prefix_sum_cl.h"
 
 #include <iostream>
 #include <stdexcept>
@@ -50,13 +51,39 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
-    gpu::gpu_mem_32u as_gpu;
+
+    unsigned int workGroupSize = 128;
+    unsigned int groups = (n + workGroupSize - 1) / workGroupSize;
+    unsigned int batchSize = 4;
+    unsigned int batchCount = 1 << batchSize;
+    unsigned int histSize = groups * batchCount;
+
+    gpu::gpu_mem_32u as_gpu, hist_gpu, hist_pref_gpu, hist_buf_gpu, bs_gpu;
     as_gpu.resizeN(n);
+    bs_gpu.resizeN(n);
+    hist_gpu.resizeN(histSize);
+    hist_pref_gpu.resizeN(histSize);
+    hist_buf_gpu.resizeN(histSize);
 
     {
-        ocl::Kernel radix(radix_kernel, radix_kernel_length, "radix");
+
+        std::string defines = " -D WORK_GROUP_SIZE=" + to_string(workGroupSize);
+        defines += " -D BATCH_SIZE=" + to_string(batchSize);
+
+        ocl::Kernel radix(radix_kernel, radix_kernel_length, "radix", defines);
         radix.compile();
+
+        ocl::Kernel count(radix_kernel, radix_kernel_length, "count", defines);
+        count.compile();
+
+        ocl::Kernel init(prefix_sum_kernel, prefix_sum_kernel_length, "init");
+        init.compile();
+
+        ocl::Kernel update(prefix_sum_kernel, prefix_sum_kernel_length, "update");
+        update.compile();
+
+        ocl::Kernel reduce(prefix_sum_kernel, prefix_sum_kernel_length, "reduce");
+        reduce.compile();
 
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
@@ -64,9 +91,30 @@ int main(int argc, char **argv) {
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            unsigned int workGroupSize = 128;
-            unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
-            radix.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, n);
+            unsigned int global_work_size = groups * workGroupSize;
+
+            for (unsigned int bit = 0; bit < sizeof(unsigned int) * CHAR_BIT; bit += batchSize) {
+                count.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, hist_gpu, n, bit);
+
+                { // pref sum
+                    unsigned int fullSize = (histSize + workGroupSize - 1) / workGroupSize * workGroupSize;
+                    init.exec(gpu::WorkSize(workGroupSize, fullSize), hist_pref_gpu, histSize);
+                    unsigned int m = histSize;
+                    auto reduceWorkSize = [&]() {
+                        return ((m + 1) / 2 + workGroupSize - 1) / workGroupSize * workGroupSize;
+                    };
+                    for (unsigned int pref_bit = 0; (1 << pref_bit) <= histSize; ++pref_bit) {
+                        update.exec(gpu::WorkSize(workGroupSize, fullSize), hist_gpu, hist_pref_gpu, histSize, pref_bit);
+                        reduce.exec(gpu::WorkSize(workGroupSize, reduceWorkSize()), hist_gpu, hist_buf_gpu, m);
+                        m = (m + 1) / 2;
+                        std::swap(hist_gpu, hist_buf_gpu);
+                    }
+                }
+
+                radix.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, bs_gpu, n, hist_pref_gpu, bit);
+                std::swap(as_gpu, bs_gpu);
+            }
+
             t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
@@ -79,6 +127,6 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <vector>
+#include <climits>
 
 
 template<typename T>


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
D:\Programms\GPGPUTasks2022\cmake-build-debug\bitonic.exe 2
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-8300H CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 12128 Mb
  Device #1: GPU. Intel(R) UHD Graphics 630. Total memory: 4851 Mb
  Device #2: GPU. NVIDIA GeForce GTX 1050. Total memory: 4095 Mb
Using device #2: GPU. NVIDIA GeForce GTX 1050. Total memory: 4095 Mb
Data generated for n=33554432!
CPU: 14.4353+-0.0718092 s
CPU: 2.28606 millions/s
GPU: 0.699333+-0.000471405 s
GPU: 47.1878 millions/s

Process finished with exit code 0
</pre>

<pre>
D:\Programms\GPGPUTasks2022\cmake-build-debug\prefix_sum.exe 2
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-8300H CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 12128 Mb
  Device #1: GPU. Intel(R) UHD Graphics 630. Total memory: 4851 Mb
  Device #2: GPU. NVIDIA GeForce GTX 1050. Total memory: 4095 Mb
Using device #2: GPU. NVIDIA GeForce GTX 1050. Total memory: 4095 Mb
______________________________________________
n=2 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0+-0 s
GPU: nan millions/s
______________________________________________
n=4 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 0 millions/s
______________________________________________
n=8 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 0 millions/s
______________________________________________
n=16 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000333333+-0.000471405 s
GPU: 0 millions/s
______________________________________________
n=32 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000666667+-0.000471405 s
GPU: 0 millions/s
______________________________________________
n=64 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000666667+-0.000471405 s
GPU: 0 millions/s
______________________________________________
n=128 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000666667+-0.000471405 s
GPU: 0 millions/s
______________________________________________
n=256 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0 millions/s
______________________________________________
n=512 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0 millions/s
______________________________________________
n=1024 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0 millions/s
______________________________________________
n=2048 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0 millions/s
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00166667+-0.000471405 s
GPU: 0 millions/s
______________________________________________
n=8192 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00133333+-0.000471405 s
GPU: 0 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00116667+-0.000372678 s
GPU: 0 millions/s
______________________________________________
n=32768 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00116667+-0.000372678 s
GPU: 0 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000666667+-0.000471405 s
CPU: 98.304 millions/s
GPU: 0.001+-0 s
GPU: 0 millions/s
______________________________________________
n=131072 values in range: [0; 1023]
CPU: 0.001+-0 s
CPU: 131.072 millions/s
GPU: 0.002+-0 s
GPU: 0 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.002+-0 s
CPU: 131.072 millions/s
GPU: 0.002+-0 s
GPU: 0 millions/s
______________________________________________
n=524288 values in range: [0; 1023]
CPU: 0.004+-0 s
CPU: 131.072 millions/s
GPU: 0.00216667+-0.000372678 s
GPU: 0 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0075+-0.0005 s
CPU: 139.81 millions/s
GPU: 0.003+-4.1159e-11 s
GPU: 333.333 millions/s
______________________________________________
n=2097152 values in range: [0; 1023]
CPU: 0.0155+-0.0005 s
CPU: 135.3 millions/s
GPU: 0.005+-0 s
GPU: 400 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0313333+-0.000942809 s
CPU: 133.861 millions/s
GPU: 0.00883333+-0.000372678 s
GPU: 452.83 millions/s
______________________________________________
n=8388608 values in range: [0; 255]
CPU: 0.0646667+-0.000471405 s
CPU: 129.721 millions/s
GPU: 0.0171667+-0.000687184 s
GPU: 466.019 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.125833+-0.00121335 s
CPU: 133.329 millions/s
GPU: 0.0323333+-0.000471405 s
GPU: 494.845 millions/s

Process finished with exit code 0
</pre>

<pre>
D:\Programms\GPGPUTasks2022\cmake-build-debug\radix.exe 2
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-8300H CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 12128 Mb
  Device #1: GPU. Intel(R) UHD Graphics 630. Total memory: 4851 Mb
  Device #2: GPU. NVIDIA GeForce GTX 1050. Total memory: 4095 Mb
Using device #2: GPU. NVIDIA GeForce GTX 1050. Total memory: 4095 Mb
Data generated for n=33554432!
CPU: 13.4228+-0.0521454 s
CPU: 2.4585 millions/s
GPU: 1.179+-0.00424264 s
GPU: 27.9898 millions/s

Process finished with exit code 0
</pre>

</p></details>

<details><summary>Вывод Travis CI</summary><p>

<pre>
./bitonic
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz. Intel(R) Corporation. Total memory: 6950 Mb
Using device #0: CPU. Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz. Intel(R) Corporation. Total memory: 6950 Mb
Data generated for n=33554432!
CPU: 3.53792+-0.0406022 s
CPU: 9.32751 millions/s
GPU: 20.1986+-0.0764907 s
GPU: 1.63377 millions/s
</pre>

<pre>
./prefix_sum
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz. Intel(R) Corporation. Total memory: 6950 Mb
Using device #0: CPU. Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz. Intel(R) Corporation. Total memory: 6950 Mb
______________________________________________
n=2 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000306+-0.000271738 s
GPU: 0 millions/s
______________________________________________
n=4 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000311667+-0.00033976 s
GPU: 0 millions/s
______________________________________________
n=8 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000286667+-0.000371503 s
GPU: 0 millions/s
______________________________________________
n=16 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000258833+-0.000367403 s
GPU: 0 millions/s
______________________________________________
n=32 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000189333+-0.000140426 s
GPU: 0 millions/s
______________________________________________
n=64 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000111167+-1.06367e-05 s
GPU: 0 millions/s
______________________________________________
n=128 values in range: [0; 1023]
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 768 millions/s
GPU: 0.000127+-8.60233e-06 s
GPU: 0 millions/s
______________________________________________
n=256 values in range: [0; 1023]
CPU: 5e-07+-5e-07 s
CPU: 512 millions/s
GPU: 0.000157+-3.95811e-06 s
GPU: 0 millions/s
______________________________________________
n=512 values in range: [0; 1023]
CPU: 1.16667e-06+-3.72678e-07 s
CPU: 438.857 millions/s
GPU: 0.000198833+-1.51153e-05 s
GPU: 0 millions/s
______________________________________________
n=1024 values in range: [0; 1023]
CPU: 2.33333e-06+-4.71405e-07 s
CPU: 438.857 millions/s
GPU: 0.000242833+-2.10509e-05 s
GPU: 0 millions/s
______________________________________________
n=2048 values in range: [0; 1023]
CPU: 5e-06+-5.68434e-14 s
CPU: 409.6 millions/s
GPU: 0.000268833+-9.24512e-06 s
GPU: 0 millions/s
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 1.05e-05+-5e-07 s
CPU: 390.095 millions/s
GPU: 0.000311833+-1.58894e-05 s
GPU: 0 millions/s
______________________________________________
n=8192 values in range: [0; 1023]
CPU: 2.06667e-05+-1.24722e-06 s
CPU: 396.387 millions/s
GPU: 0.00047+-1.99499e-05 s
GPU: 0 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 4.25e-05+-2.5e-06 s
CPU: 385.506 millions/s
GPU: 0.000652167+-4.24202e-05 s
GPU: 0 millions/s
______________________________________________
n=32768 values in range: [0; 1023]
CPU: 7.88333e-05+-3.8478e-06 s
CPU: 415.662 millions/s
GPU: 0.000741167+-2.80619e-05 s
GPU: 0 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000148667+-4.71405e-07 s
CPU: 440.825 millions/s
GPU: 0.0011545+-3.5869e-05 s
GPU: 0 millions/s
______________________________________________
n=131072 values in range: [0; 1023]
CPU: 0.000329333+-1.666e-05 s
CPU: 397.992 millions/s
GPU: 0.001807+-6.37992e-05 s
GPU: 0 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000635833+-1.17391e-05 s
CPU: 412.284 millions/s
GPU: 0.0030475+-0.000110885 s
GPU: 0 millions/s
______________________________________________
n=524288 values in range: [0; 1023]
CPU: 0.001357+-3.72022e-05 s
CPU: 386.358 millions/s
GPU: 0.0060895+-0.000345824 s
GPU: 0 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00267533+-7.99743e-05 s
CPU: 391.942 millions/s
GPU: 0.0122685+-0.000404766 s
GPU: 81.5096 millions/s
______________________________________________
n=2097152 values in range: [0; 1023]
CPU: 0.00535817+-8.86856e-05 s
CPU: 391.394 millions/s
GPU: 0.0243153+-0.000319948 s
GPU: 82.2526 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0114243+-0.000249141 s
CPU: 367.138 millions/s
GPU: 0.0485612+-0.00132648 s
GPU: 82.3703 millions/s
______________________________________________
n=8388608 values in range: [0; 255]
CPU: 0.021831+-0.000595089 s
CPU: 384.252 millions/s
GPU: 0.107725+-0.00390076 s
GPU: 74.2631 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0431543+-0.000990872 s
CPU: 388.772 millions/s
GPU: 0.226602+-0.00490333 s
GPU: 70.6085 millions/s
</pre>

<pre>
./radix
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz. Intel(R) Corporation. Total memory: 6950 Mb
Using device #0: CPU. Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz. Intel(R) Corporation. Total memory: 6950 Mb
Data generated for n=33554432!
CPU: 3.10207+-0.0153626 s
CPU: 10.6381 millions/s
GPU: 5.56987+-0.0313328 s
GPU: 5.92473 millions/s
</pre>

</p></details>