### PR TITLE
Task06 Ilya Voronin SPbU

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,56 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void bitonic(__global float *as, unsigned int N, unsigned int chunk_size, unsigned int global_chunk_size,
+                      int use_local_memory /*, __local float *storage */ )
+{
+
+    __local float storage[1024];
+
+    unsigned int i = get_global_id(0);
+    unsigned int hcs = chunk_size / 2;
+
+    unsigned int group_size = get_local_size(0);
+
+    bool ascending = ((i / (global_chunk_size / 2)) % 2) == 0;
+
+    if (use_local_memory) {
+        unsigned int offset = i / group_size * group_size * 2;
+        unsigned int local_id = get_local_id(0);
+        unsigned int global_id = offset + i % group_size;
+        storage[local_id] = as[global_id];
+        storage[local_id + group_size] = as[global_id + group_size];
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        while (chunk_size > 1) {
+            unsigned int ind1 = i / (chunk_size / 2) * chunk_size + i % (chunk_size / 2) - offset;
+            unsigned int ind2 = ind1 + chunk_size / 2;
+            float elem1 = storage[ind1];
+            float elem2 = storage[ind2];
+            if ((ascending && elem1 > elem2) || (!ascending && elem1 < elem2)) {
+                storage[ind1] = elem2;
+                storage[ind2] = elem1;
+            }
+
+            chunk_size /= 2;
+
+            barrier(CLK_LOCAL_MEM_FENCE);
+        }
+
+        as[global_id] = storage[local_id];
+        as[global_id + group_size] = storage[local_id + group_size];
+    } else {
+        unsigned int global_id = i / hcs * chunk_size + i % hcs;
+        float elem1 = as[global_id];
+        float elem2 = as[global_id + hcs];
+        if ((ascending && elem1 > elem2) || (!ascending && elem1 < elem2)) {
+            as[global_id] = elem2;
+            as[global_id + hcs] = elem1;
+        }
+    }
+
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,19 @@
-// TODO
+
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void prefix_sum(__global unsigned int *as, __global unsigned int *bs, unsigned int byte_num) {
+    unsigned int i = get_global_id(0);
+    if (((1 << byte_num) & (i + 1)) != 0) {
+        bs[i] += as[((i + 1) >> byte_num) - 1];
+    }
+}
+
+__kernel void prefix_sum_reduce(__global unsigned int *as, __global unsigned int *bs)
+{
+    unsigned int i = get_global_id(0);
+    bs[i] = as[i * 2] + as[i * 2 + 1];
+}

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -1,3 +1,78 @@
-__kernel void radix(__global unsigned int *as) {
-    // TODO
+
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define WORK_GROUP_SIZE 128
+#define MAX_NUM (1 << 4) // = (1 << byte_cnt)
+
+__kernel void radix_count(__global unsigned int *as, unsigned int N, __global unsigned int *bs, unsigned int byte_num, unsigned int byte_cnt) {
+    unsigned int global_id = get_global_id(0);
+    unsigned int local_id = get_local_id(0);
+    __local unsigned int storage[WORK_GROUP_SIZE];
+    __local unsigned int res[MAX_NUM];
+
+    storage[local_id] = as[global_id];
+    if (local_id < (1 << byte_cnt)) {
+        res[local_id] = 0;
+    }
+
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_id == 0) {
+        for (unsigned int i = 0; i < WORK_GROUP_SIZE; i++) {
+            unsigned int j = (storage[i] >> byte_num) & ((1 << byte_cnt) - 1);
+            res[j] += 1;
+        }
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_id < (1 << byte_cnt)) {
+        bs[local_id * (N / WORK_GROUP_SIZE) + global_id / WORK_GROUP_SIZE] = res[local_id];
+    }
+}
+
+__kernel void radix_sort(__global unsigned int *as, unsigned int N, __global unsigned int *prefix, __global unsigned int *res, unsigned int byte_num, unsigned int byte_cnt) {
+    unsigned int global_id = get_global_id(0);
+    unsigned int local_id = get_local_id(0);
+    unsigned int num_prefix = global_id / WORK_GROUP_SIZE;
+
+    __local unsigned int storage[WORK_GROUP_SIZE];
+    __local unsigned int cnts[MAX_NUM];
+    __local unsigned int prev_counts[MAX_NUM];
+    __local unsigned int local_res[WORK_GROUP_SIZE];
+
+    storage[local_id] = as[global_id];
+
+    if (local_id < (1 << byte_cnt)) {
+        if (num_prefix == 0) {
+            if (local_id == 0) {
+                prev_counts[local_id] = 0;
+            } else {
+                prev_counts[local_id] = prefix[local_id * (N / WORK_GROUP_SIZE) - 1];
+            }
+        } else {
+            prev_counts[local_id] = prefix[local_id * (N / WORK_GROUP_SIZE) + num_prefix - 1];
+        }
+        cnts[local_id] = 0;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+
+    if (local_id == 0) {
+        for (unsigned int i = 0; i < WORK_GROUP_SIZE; i++) {
+            unsigned int j = (storage[i] >> byte_num) & ((1 << byte_cnt) - 1);
+            local_res[i] = prev_counts[j] + cnts[j];
+            cnts[j] += 1;
+        }
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    res[local_res[local_id]] = storage[local_id];
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -22,6 +22,22 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
+template <typename T>
+T getDeviceInfo(cl_device_id deviceId, cl_device_info paramName) {
+    T res;
+    OCL_SAFE_CALL(clGetDeviceInfo(deviceId, paramName, sizeof(T), &res, nullptr));
+    return res;
+}
+
+template <typename T>
+std::vector<T> getArrayDeviceInfo(cl_device_id deviceId, cl_device_info paramName) {
+    size_t valLength = 0;
+    OCL_SAFE_CALL(clGetDeviceInfo(deviceId, paramName, 0, nullptr, &valLength));
+    std::vector<T> info(valLength);
+    OCL_SAFE_CALL(clGetDeviceInfo(deviceId, paramName, valLength, info.data(), nullptr));
+    return info;
+}
+
 
 int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
@@ -50,10 +66,27 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
+    int localMemorySize = getDeviceInfo<cl_ulong>(device.device_id_opencl, CL_DEVICE_LOCAL_MEM_SIZE);
+    std::vector<size_t> maxWorkItemSizes = getArrayDeviceInfo<size_t>(device.device_id_opencl, CL_DEVICE_MAX_WORK_ITEM_SIZES);
+    unsigned int n2 = 1;
+    while (n2 < n) {
+        n2 *= 2;
+    }
+    as.resize(n2);
+    for (int i = n; i < n2; i++) {
+        as[i] = CL_FLT_MAX;
+    }
 
+    int occupancy = 8;
+    int maxChunk = localMemorySize / sizeof(float) / occupancy;
+    maxChunk = std::min(int(maxWorkItemSizes[0]) * 2, maxChunk);
+
+    maxChunk = std::min(1024, maxChunk); // hardcoding limit, because intel do not support dynamic local memory
+
+    std::cout << "Max chunk size: " << maxChunk << std::endl;
     {
         ocl::Kernel bitonic(bitonic_kernel, bitonic_kernel_length, "bitonic");
         bitonic.compile();
@@ -61,12 +94,41 @@ int main(int argc, char **argv) {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             as_gpu.writeN(as.data(), n);
-
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            unsigned int workGroupSize = 128;
-            unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
-            bitonic.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, n);
+            unsigned int curr_chunk_size = 2;
+            unsigned int global_work_size = n2 / 2;
+
+            while (true) {
+                unsigned int curr_sub_chunk_size = curr_chunk_size;
+
+                while (curr_sub_chunk_size > 1) {
+                    bool use_local_memory = curr_sub_chunk_size < maxChunk && curr_sub_chunk_size > 2;
+                    unsigned int workGroupSize = 128;
+
+                    //int local_mem_arr_size = 0;
+                    //ocl::OpenCLKernelArg arg = ocl::OpenCLKernelArg();
+                    if (use_local_memory) {
+                        workGroupSize = std::max((unsigned int)(128), curr_sub_chunk_size / 2);
+                        //local_mem_arr_size = workGroupSize * 2 * sizeof(float);
+                    }
+                    //arg.size = local_mem_arr_size;
+                    //arg.is_null = false;
+                    //arg.value = NULL;
+
+
+                    bitonic.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, n2,
+                                 curr_sub_chunk_size, curr_chunk_size, int(use_local_memory));
+                    if (use_local_memory) {
+                        break;
+                    }
+                    curr_sub_chunk_size /= 2;
+                }
+                if (curr_chunk_size >= n2) {
+                    break;
+                }
+                curr_chunk_size *= 2;
+            }
             t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
@@ -79,6 +141,6 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
 		{
             std::vector<unsigned int> result(n, 0);
             timer t;
-            for (int iter = 0; iter < 1; ++iter) {
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
                 as_gpu.writeN(as.data(), n);
                 res_gpu.writeN(result.data(), n);
 
@@ -101,7 +101,8 @@ int main(int argc, char **argv)
 
                 int bit_num = 0;
                 while (true) {
-                    prefix_sum.exec(gpu::WorkSize(128, n), as_gpu, res_gpu, bit_num);
+                    int group_size = std::min(n, (unsigned int)(128));
+                    prefix_sum.exec(gpu::WorkSize(group_size, n), as_gpu, res_gpu, bit_num);
                     if ((1 << bit_num) >= n) {
                         break;
                     }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -25,6 +25,15 @@ int main(int argc, char **argv)
 	int benchmarkingIters = 10;
 	unsigned int max_n = (1 << 24);
 
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
+    ocl::Kernel prefix_sum(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum");
+    ocl::Kernel prefix_sum_reduce(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_reduce");
+    prefix_sum.compile();
+
 	for (unsigned int n = 2; n <= max_n; n *= 2) {
 		std::cout << "______________________________________________" << std::endl;
 		unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
@@ -35,8 +44,13 @@ int main(int argc, char **argv)
 		for (int i = 0; i < n; ++i) {
 			as[i] = r.next(0, values_range);
 		}
+        gpu::gpu_mem_32u as_gpu, bs_gpu, res_gpu;
+        as_gpu.resizeN(n);
+        bs_gpu.resizeN(n);
+        res_gpu.resizeN(n);
 
-		std::vector<unsigned int> bs(n, 0);
+
+        std::vector<unsigned int> bs(n, 0);
 		{
 			for (int i = 0; i < n; ++i) {
 				bs[i] = as[i];
@@ -77,7 +91,37 @@ int main(int argc, char **argv)
 		}
 
 		{
-			// TODO: implement on OpenCL
+            std::vector<unsigned int> result(n, 0);
+            timer t;
+            for (int iter = 0; iter < 1; ++iter) {
+                as_gpu.writeN(as.data(), n);
+                res_gpu.writeN(result.data(), n);
+
+                t.restart();
+
+                int bit_num = 0;
+                while (true) {
+                    prefix_sum.exec(gpu::WorkSize(128, n), as_gpu, res_gpu, bit_num);
+                    if ((1 << bit_num) >= n) {
+                        break;
+                    }
+                    bit_num += 1;
+                    int global_work_size = n / (1 << bit_num);
+                    int work_group_size = std::min(global_work_size, 128);
+                    prefix_sum_reduce.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, bs_gpu);
+                    as_gpu.swap(bs_gpu);
+                }
+
+                t.nextLap();
+            }
+
+            res_gpu.readN(result.data(), n);
+            for (int i = 0; i < n; ++i) {
+                EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
+            }
+
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
 		}
 	}
 }

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -33,8 +33,8 @@ int main(int argc, char **argv) {
     context.init(device.device_id_opencl);
     context.activate();
 
-    int benchmarkingIters = 1;
-    unsigned int n = 1024 * 1024;
+    int benchmarkingIters = 10;
+    unsigned int n = 32 * 1024 * 1024;
     unsigned int cnt_bits_sort = 4;
     unsigned int work_group_size = 128;
 

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -6,6 +6,9 @@
 
 // Этот файл будет сгенерирован автоматически в момент сборки - см. convertIntoHeader в CMakeLists.txt:18
 #include "cl/radix_cl.h"
+#include "cl/prefix_sum_cl.h"
+#include "cl/bitonic_cl.h"
+
 
 #include <iostream>
 #include <stdexcept>
@@ -30,8 +33,11 @@ int main(int argc, char **argv) {
     context.init(device.device_id_opencl);
     context.activate();
 
-    int benchmarkingIters = 10;
-    unsigned int n = 32 * 1024 * 1024;
+    int benchmarkingIters = 1;
+    unsigned int n = 1024 * 1024;
+    unsigned int cnt_bits_sort = 4;
+    unsigned int work_group_size = 128;
+
     std::vector<unsigned int> as(n, 0);
     FastRandom r(n);
     for (unsigned int i = 0; i < n; ++i) {
@@ -50,13 +56,26 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
-    gpu::gpu_mem_32u as_gpu;
+    gpu::gpu_mem_32u as_gpu, bs_gpu, cs_gpu, ds_gpu, res_gpu;
+    int prefix_size = n / work_group_size * (1 << cnt_bits_sort);
+
     as_gpu.resizeN(n);
+    bs_gpu.resizeN(prefix_size);
+    cs_gpu.resizeN(prefix_size);
+    ds_gpu.resizeN(prefix_size);
+    res_gpu.resizeN(n);
+    std::vector<unsigned int> empty_prefix_vector(prefix_size, 0);
+    std::vector<unsigned int> tmp_vector(prefix_size, 0);
 
     {
-        ocl::Kernel radix(radix_kernel, radix_kernel_length, "radix");
-        radix.compile();
+        ocl::Kernel radix_count(radix_kernel, radix_kernel_length, "radix_count");
+        ocl::Kernel radix_prefix(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum");
+        ocl::Kernel radix_prefix_reduce(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_reduce");
+        ocl::Kernel radix_sort(radix_kernel, radix_kernel_length, "radix_sort");
+        radix_count.compile();
+        radix_prefix.compile();
+        radix_prefix_reduce.compile();
+        radix_sort.compile();
 
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
@@ -64,21 +83,45 @@ int main(int argc, char **argv) {
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            unsigned int workGroupSize = 128;
-            unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
-            radix.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, n);
+            for (int i = 0; i <= 32; i += cnt_bits_sort) {
+                bs_gpu.writeN(empty_prefix_vector.data(), prefix_size);
+                cs_gpu.writeN(empty_prefix_vector.data(), prefix_size);
+                ds_gpu.writeN(empty_prefix_vector.data(), prefix_size);
+
+                radix_count.exec(gpu::WorkSize(work_group_size, n), as_gpu, n,bs_gpu, i, cnt_bits_sort);
+
+
+                int bit_num = 0;
+                while (true) {
+                    radix_prefix.exec(gpu::WorkSize(work_group_size, prefix_size), bs_gpu, ds_gpu, bit_num);
+                    if ((1 << bit_num) >= prefix_size) {
+                        break;
+                    }
+                    bit_num += 1;
+                    unsigned int global_work_size = prefix_size / (1 << bit_num);
+                    unsigned int work_group_size1 = std::min(global_work_size, work_group_size);
+
+                    radix_prefix_reduce.exec(gpu::WorkSize(work_group_size1, global_work_size), bs_gpu, cs_gpu);
+                    bs_gpu.swap(cs_gpu);
+                }
+
+                radix_sort.exec(gpu::WorkSize(128, n), as_gpu, n, ds_gpu, res_gpu, i, cnt_bits_sort);
+                res_gpu.swap(as_gpu);
+            }
+
+
             t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
 
-        as_gpu.readN(as.data(), n);
+        res_gpu.readN(as.data(), n);
     }
 
     // Проверяем корректность результатов
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            for (int i = 0; i <= 32; i += cnt_bits_sort) {
+            for (int i = 0; i < 32; i += cnt_bits_sort) {
                 bs_gpu.writeN(empty_prefix_vector.data(), prefix_size);
                 cs_gpu.writeN(empty_prefix_vector.data(), prefix_size);
                 ds_gpu.writeN(empty_prefix_vector.data(), prefix_size);
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
 
-        res_gpu.readN(as.data(), n);
+        as_gpu.readN(as.data(), n);
     }
 
     // Проверяем корректность результатов


### PR DESCRIPTION
<details><summary>Локальный вывод bitonic sort</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. GeForce GTX 1050 Ti with Max-Q Design. Total memory: 4042 Mb
  Device #1: CPU. Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz. Intel(R) Corporation. Total memory: 15690 Mb
Using device #0: GPU. GeForce GTX 1050 Ti with Max-Q Design. Total memory: 4042 Mb
Data generated for n=33554432!
CPU: 2.82531+-0.0109673 s
CPU: 11.6801 millions/s
Max chunk size: 1024
GPU: 0.451458+-6.48068e-05 s
GPU: 73.0964 millions/s
</pre>

</p></details>


<details><summary>Локальный вывод prefix summ</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. GeForce GTX 1050 Ti with Max-Q Design. Total memory: 4042 Mb
  Device #1: CPU. Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz. Intel(R) Corporation. Total memory: 15690 Mb
Using device #0: GPU. GeForce GTX 1050 Ti with Max-Q Design. Total memory: 4042 Mb
______________________________________________
n=2 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 2.48333e-05+-3.72678e-07 s
GPU: 0.0805369 millions/s
______________________________________________
n=4 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 4.1e-05+-0 s
GPU: 0.097561 millions/s
______________________________________________
n=8 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 5.81667e-05+-3.72678e-07 s
GPU: 0.137536 millions/s
______________________________________________
n=16 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 7.4e-05+-0 s
GPU: 0.216216 millions/s
______________________________________________
n=32 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 9.01667e-05+-3.72678e-07 s
GPU: 0.354898 millions/s
______________________________________________
n=64 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000106333+-4.71405e-07 s
GPU: 0.601881 millions/s
______________________________________________
n=128 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000123333+-7.45356e-07 s
GPU: 1.03784 millions/s
______________________________________________
n=256 values in range: [0; 1023]
CPU: 3.33333e-07+-4.71405e-07 s
CPU: 768 millions/s
GPU: 0.00014+-8.16497e-07 s
GPU: 1.82857 millions/s
______________________________________________
n=512 values in range: [0; 1023]
CPU: 1e-06+-0 s
CPU: 512 millions/s
GPU: 0.000155833+-3.72678e-07 s
GPU: 3.28556 millions/s
______________________________________________
n=1024 values in range: [0; 1023]
CPU: 1.83333e-06+-3.72678e-07 s
CPU: 558.545 millions/s
GPU: 0.000193667+-1.48511e-05 s
GPU: 5.28744 millions/s
______________________________________________
n=2048 values in range: [0; 1023]
CPU: 3.16667e-06+-3.72678e-07 s
CPU: 646.737 millions/s
GPU: 0.000208333+-7.38617e-06 s
GPU: 9.8304 millions/s
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 6.33333e-06+-4.71405e-07 s
CPU: 646.737 millions/s
GPU: 0.000206+-1e-06 s
GPU: 19.8835 millions/s
______________________________________________
n=8192 values in range: [0; 1023]
CPU: 1.3e-05+-0 s
CPU: 630.154 millions/s
GPU: 0.000225333+-4.71405e-07 s
GPU: 36.355 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 2.6e-05+-0 s
CPU: 630.154 millions/s
GPU: 0.000244833+-3.72678e-07 s
GPU: 66.919 millions/s
______________________________________________
n=32768 values in range: [0; 1023]
CPU: 5.2e-05+-0 s
CPU: 630.154 millions/s
GPU: 0.000285167+-1.81514e-05 s
GPU: 114.908 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000105+-0 s
CPU: 624.152 millions/s
GPU: 0.000315+-1.82574e-06 s
GPU: 208.051 millions/s
______________________________________________
n=131072 values in range: [0; 1023]
CPU: 0.000211+-0 s
CPU: 621.194 millions/s
GPU: 0.000387+-1e-06 s
GPU: 338.687 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000421333+-4.71405e-07 s
CPU: 622.177 millions/s
GPU: 0.000593833+-2.03443e-06 s
GPU: 441.444 millions/s
______________________________________________
n=524288 values in range: [0; 1023]
CPU: 0.0009645+-2.13756e-05 s
CPU: 543.585 millions/s
GPU: 0.00101933+-5.49747e-06 s
GPU: 514.344 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00215183+-0.000104484 s
CPU: 487.294 millions/s
GPU: 0.0018405+-1.32256e-05 s
GPU: 569.723 millions/s
______________________________________________
n=2097152 values in range: [0; 1023]
CPU: 0.00418517+-0.000157605 s
CPU: 501.092 millions/s
GPU: 0.003461+-2.81898e-05 s
GPU: 605.938 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00731783+-3.0449e-05 s
CPU: 573.162 millions/s
GPU: 0.00677367+-3.00148e-05 s
GPU: 619.207 millions/s
______________________________________________
n=8388608 values in range: [0; 255]
CPU: 0.0148375+-0.000169138 s
CPU: 565.365 millions/s
GPU: 0.0132595+-5.18548e-05 s
GPU: 632.649 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0290532+-4.08999e-05 s
CPU: 577.466 millions/s
GPU: 0.026351+-0.000158414 s
GPU: 636.682 millions/s
</pre>

</p></details>

<details><summary>Локальный вывод radix sort</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. GeForce GTX 1050 Ti with Max-Q Design. Total memory: 4042 Mb
  Device #1: CPU. Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz. Intel(R) Corporation. Total memory: 15690 Mb
Using device #0: GPU. GeForce GTX 1050 Ti with Max-Q Design. Total memory: 4042 Mb
Data generated for n=33554432!
CPU: 2.77023+-0.0218474 s
CPU: 11.9124 millions/s
GPU: 0.471342+-0.001053 s
GPU: 70.0129 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI bitonic sort</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
Data generated for n=33554432!
CPU: 3.98032+-0.0016073 s
CPU: 8.29078 millions/s
Max chunk size: 1024
GPU: 11.102+-0.0161061 s
GPU: 2.97243 millions/s
</pre>

</p></details>


<details><summary>Вывод Github CI radix sort</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
Data generated for n=33554432!
CPU: 3.62598+-0.000865439 s
CPU: 9.10099 millions/s
GPU: 0.901611+-0.00448068 s
GPU: 36.6011 millions/s
</pre>

</p></details>

Очень странные результаты у radix sort и префикс сумм. Локально на процессоре(с OpenCl) работает примерно так же как и на видеокарте(74 vs 70)