### PR TITLE
Task06 Шелухина Екатерина HSE 

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,45 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define WORK_GROUP_SIZE 128
+
+__kernel void local_bitonic(__global float *as, unsigned int n, unsigned int i, unsigned int j) {
+    unsigned int global_id = get_global_id(0);
+    unsigned int local_id = get_local_id(0);
+
+    __local float local_as[WORK_GROUP_SIZE];
+
+    local_as[local_id] = global_id < n ? as[global_id] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (; j > 0; j /= 2) {
+        if (j + local_id < n && local_id % (2 * j) < j) {
+            if (global_id % (2 * i) < i == local_as[local_id] > local_as[local_id + j]) {
+                float tmp = local_as[local_id];
+                local_as[local_id] = local_as[local_id + j];
+                local_as[local_id + j] = tmp;
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (global_id < n) {
+        as[global_id] = local_as[local_id];
+    }
+}
+
+
+__kernel void bitonic(__global float *as, unsigned int n, unsigned int i, unsigned int j) {
+    unsigned int global_id = get_global_id(0);
+
+    if (j + global_id < n && global_id % (2 * j) < j) {
+        if (global_id % (2 * i) < i == as[global_id] > as[global_id + j]) {
+            float tmp = as[global_id];
+            as[global_id] = as[global_id + j];
+            as[global_id + j] = tmp;
+        }
+    }
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,26 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void prefix_sum(__global unsigned int *as, __global unsigned int *bs, unsigned int bit, unsigned int n) {
+    unsigned int global_id = get_global_id(0);
+    if (global_id >= n) {
+        return;
+    }
+
+    unsigned int ind = global_id + 1;
+
+    if ((ind >> bit) & 1) {
+        as[global_id] += bs[(ind >> bit) - 1];
+    }
+}
+
+__kernel void reduce_sum(__global unsigned int *as, __global unsigned int *cs, unsigned int n) {
+    unsigned int global_id = get_global_id(0);
+    if (global_id >= n) {
+        return;
+    }
+    cs[global_id] = as[global_id * 2] + as[global_id * 2 + 1];
+}

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -50,13 +50,15 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
     {
         ocl::Kernel bitonic(bitonic_kernel, bitonic_kernel_length, "bitonic");
         bitonic.compile();
+
+        ocl::Kernel local_bitonic(bitonic_kernel, bitonic_kernel_length, "local_bitonic");
+        local_bitonic.compile();
 
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
@@ -66,7 +68,13 @@ int main(int argc, char **argv) {
 
             unsigned int workGroupSize = 128;
             unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
-            bitonic.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, n);
+            for (unsigned int i = 2; i <= global_work_size; i *= 2) {
+                unsigned int j = i / 2;
+                for (; j >= workGroupSize; j /= 2) {
+                    bitonic.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, n, i, j);
+                }
+                local_bitonic.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, n, i, j);
+            }
             t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
@@ -79,6 +87,5 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
     return 0;
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -103,11 +103,13 @@ int main(int argc, char **argv)
                 t.restart();
                 unsigned int workGroupSize = 256;
                 unsigned int prefix_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
-                unsigned int reduce_work_size = (n / 2 + workGroupSize - 1) / workGroupSize * workGroupSize;
+                unsigned int m = n;
 
                 for (unsigned int bit = 0; (1 << bit) <= n; bit++) {
                     prefix_sum.exec(gpu::WorkSize(workGroupSize, prefix_work_size), bs_gpu, as_gpu, bit, n);
-                    reduce_sum.exec(gpu::WorkSize(workGroupSize, reduce_work_size), as_gpu, cs_gpu, n >> (bit + 1));
+                    m = (m + 1) / 2;
+                    unsigned int reduce_work_size = (m + workGroupSize - 1) / workGroupSize * workGroupSize;
+                    reduce_sum.exec(gpu::WorkSize(workGroupSize, reduce_work_size), as_gpu, cs_gpu, m);
                     std::swap(as_gpu, cs_gpu);
                 }
                 t.nextLap();


### PR DESCRIPTION
Локальный вывод: 
```       
./prefix_sum 1
______________________________________________
n=2 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-8210Y CPU @ 1.60GHz. Intel. Total memory: 8192 Mb
  Device #1: GPU. Intel(R) UHD Graphics 617. Total memory: 1536 Mb
Using device #1: GPU. Intel(R) UHD Graphics 617. Total memory: 1536 Mb
GPU: 0.00154517+-0.000142487 s
GPU: 0.00129436 millions/s
GPU results should be equal to CPU results! But 598 != 239, /Users/eshelukhina/Desktop/GPGPUTasks2022/src/main_prefix_sum.cpp:120
libc++abi: terminating with uncaught exception of type std::runtime_error: GPU results should be equal to CPU results!
Abort trap: 6
```
```
./bitonic 1
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-8210Y CPU @ 1.60GHz. Intel. Total memory: 8192 Mb
  Device #1: GPU. Intel(R) UHD Graphics 617. Total memory: 1536 Mb
Using device #1: GPU. Intel(R) UHD Graphics 617. Total memory: 1536 Mb
Data generated for n=33554432!
CPU: 3.73345+-0.164894 s
CPU: 8.83901 millions/s
GPU: 2.90252+-0.053717 s
GPU: 11.3694 millions/s
```