### PR TITLE
Task06 Дмитрий Вихорев HSE

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,33 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void bitonic(__global float *as, int n, int k, int m) {
+    int id = get_global_id(0);
+    bool odd = (id / m) % 2, inc = as[id] < as[id + k / 2];
+    if (id + k / 2 < n && id % k < k / 2 && (odd && inc || !odd && !inc)) {
+        float tmp = as[id];
+        as[id] = as[id + k / 2];
+        as[id + k / 2] = tmp;
+    }
+}
+
+#define GROUP_SIZE 128
+
+__kernel void bitonic_local(__global float *as, int n, int k, int m) {
+    int id = get_global_id(0);
+    int local_id = get_local_id(0);
+    __local float local_as[GROUP_SIZE];
+    local_as[local_id] = as[id];
+    barrier(CLK_LOCAL_MEM_FENCE);
+    bool odd = (id / m) % 2, inc = as[id] < as[id + k / 2];
+    if (id + k / 2 < n && id % k < k / 2 && (odd && inc || !odd && !inc)) {
+        float tmp = local_as[local_id];
+        local_as[local_id] = local_as[local_id + k / 2];
+        local_as[local_id + k / 2] = tmp;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+    as[id] = local_as[local_id];
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,20 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void prefix_sum(__global unsigned int *as, __global unsigned int *bs, unsigned int n, unsigned int shift) {
+    unsigned int i = get_global_id(0);
+    if (i >= n)
+        return;
+    if (((i + 1) >> shift) & 1)
+        bs[i] += as[((i + 1) >> shift) - 1];
+}
+
+__kernel void pairwise_sum(__global unsigned int *as, __global unsigned int *bs, unsigned int n) {
+    unsigned int i = get_global_id(0);
+    if (i >= n)
+        return;
+    bs[i] = as[2 * i] + as[2 * i + 1];
+}

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -1,3 +1,45 @@
-__kernel void radix(__global unsigned int *as) {
-    // TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void get_zeros_and_ones(__global unsigned int *as, unsigned int n, unsigned int digit,
+                                 __global unsigned int *zeros, __global unsigned int *ones) {
+    unsigned int i = get_global_id(0);
+    if (i >= n)
+        return;
+    unsigned int tmp = (as[i] >> digit) & 1;
+    ones[i] = tmp;
+    zeros[i] = 1 - tmp;
+}
+
+__kernel void prefix_sum(__global unsigned int *as, __global unsigned int *bs, unsigned int n, unsigned int shift,
+                         __global unsigned int *last, unsigned int change_last) {
+    unsigned int i = get_global_id(0);
+    if (i >= n)
+        return;
+    if (((i + 1) >> shift) & 1)
+        bs[i] += as[((i + 1) >> shift) - 1];
+    if (change_last != 0 && i == n - 1)
+        last[0] = bs[i];
+}
+
+__kernel void pairwise_sum(__global unsigned int *as, __global unsigned int *bs, unsigned int n) {
+    unsigned int i = get_global_id(0);
+    if (i >= n)
+        return;
+    bs[i] = as[2 * i] + as[2 * i + 1];
+}
+
+__kernel void radix(__global unsigned int *as, __global unsigned int *bs,
+                    __global unsigned int *prefix_zeros, __global unsigned int *prefix_ones,
+                    unsigned int n, unsigned int digit, __global unsigned int *last) {
+    unsigned int i = get_global_id(0);
+    if (i >= n)
+        return;
+    if ((as[i] >> digit) & 1)
+        bs[last[0] + prefix_ones[i] - 1] = as[i];
+    else
+        bs[prefix_zeros[i] - 1] = as[i];
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
     context.init(device.device_id_opencl);
     context.activate();
 
-    int benchmarkingIters = 10;
+    int benchmarkingIters = 1;
     unsigned int n = 32 * 1024 * 1024;
     std::vector<float> as(n, 0);
     FastRandom r(n);
@@ -50,35 +50,46 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
-
     {
         ocl::Kernel bitonic(bitonic_kernel, bitonic_kernel_length, "bitonic");
+        ocl::Kernel bitonic_local(bitonic_kernel, bitonic_kernel_length, "bitonic_local");
         bitonic.compile();
-
+        bitonic_local.compile();
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             as_gpu.writeN(as.data(), n);
-
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
             unsigned int workGroupSize = 128;
             unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
-            bitonic.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, n);
+
+            unsigned int m = 1;
+            while (m < global_work_size) {
+                m *= 2;
+                unsigned int k = m;
+                while (k >= workGroupSize) {
+                    bitonic.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, n, k, m);
+                    k /= 2;
+                }
+                while (k >= 2) {
+                    bitonic_local.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, n, k, m);
+                    k /= 2;
+                }
+            }
+
             t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
-
         as_gpu.readN(as.data(), n);
     }
-
     // Проверяем корректность результатов
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }


### PR DESCRIPTION
<details><summary>Локальный вывод (bitonic sort)</summary><p>
<pre>
C:\reps\GPGPUTasks\cmake-build-debug\bitonic.exe 2
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-10870H CPU @ 2.20GHz. Intel(R) Corporation. Total memory: 16215 Mb
  Device #1: GPU. Intel(R) UHD Graphics. Total memory: 6486 Mb
  Device #2: GPU. NVIDIA GeForce RTX 3080 Laptop GPU. Total memory: 8191 Mb
Using device #2: GPU. NVIDIA GeForce RTX 3080 Laptop GPU. Total memory: 8191 Mb
Data generated for n=33554432!
CPU: 16.7482+-0.0539303 s
CPU: 1.97036 millions/s
GPU: 0.1435+-0.00221736 s
GPU: 229.965 millions/s
</pre>
</p></details>

<details><summary>Github CI (bitonic sort)</summary><p>
<pre>
Run ./bitonic
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
Data generated for n=33554432!
CPU: 3.19506+-0.000723305 s
CPU: 10.3284 millions/s
GPU: 6.40059+-0.0193617 s
GPU: 5.15577 millions/s
</pre>
</p></details>

<details><summary>Локальный вывод (prefix sum)</summary><p>
<pre>
C:\reps\GPGPUTasks\cmake-build-debug\prefix_sum.exe 2
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-10870H CPU @ 2.20GHz. Intel(R) Corporation. Total memory: 16215 Mb
  Device #1: GPU. Intel(R) UHD Graphics. Total memory: 6486 Mb
  Device #2: GPU. NVIDIA GeForce RTX 3080 Laptop GPU. Total memory: 8191 Mb
Using device #2: GPU. NVIDIA GeForce RTX 3080 Laptop GPU. Total memory: 8191 Mb
______________________________________________
n=2 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.0005+-0.0005 s
GPU: 0.004 millions/s
______________________________________________
n=4 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 0.024 millions/s
______________________________________________
n=8 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 0.048 millions/s
______________________________________________
n=16 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000333333+-0.000471405 s
GPU: 0.048 millions/s
______________________________________________
n=32 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.0005+-0.0005 s
GPU: 0.064 millions/s
______________________________________________
n=64 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.0005+-0.0005 s
GPU: 0.128 millions/s
______________________________________________
n=128 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000666667+-0.000471405 s
GPU: 0.192 millions/s
______________________________________________
n=256 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0.256 millions/s
______________________________________________
n=512 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0.512 millions/s
______________________________________________
n=1024 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000833333+-0.000372678 s
GPU: 1.2288 millions/s
______________________________________________
n=2048 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 2.048 millions/s
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 4.096 millions/s
______________________________________________
n=8192 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 8.192 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 16.384 millions/s
______________________________________________
n=32768 values in range: [0; 1023]
CPU: 0.0005+-0.0005 s
CPU: 65.536 millions/s
GPU: 0.001+-0 s
GPU: 32.768 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.001+-0 s
CPU: 65.536 millions/s
GPU: 0.001+-0 s
GPU: 65.536 millions/s
______________________________________________
n=131072 values in range: [0; 1023]
CPU: 0.00166667+-0.000471405 s
CPU: 78.6432 millions/s
GPU: 0.001+-0 s
GPU: 131.072 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.003+-4.1159e-11 s
CPU: 87.3813 millions/s
GPU: 0.001+-0 s
GPU: 262.144 millions/s
______________________________________________
n=524288 values in range: [0; 1023]
CPU: 0.0065+-0.0005 s
CPU: 80.6597 millions/s
GPU: 0.00183333+-0.000372678 s
GPU: 285.975 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0116667+-0.000471405 s
CPU: 89.8779 millions/s
GPU: 0.00166667+-0.000471405 s
GPU: 629.146 millions/s
______________________________________________
n=2097152 values in range: [0; 1023]
CPU: 0.0233333+-0.000471405 s
CPU: 89.8779 millions/s
GPU: 0.017+-0 s
GPU: 123.362 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0478333+-0.000372678 s
CPU: 87.6858 millions/s
GPU: 0.0253333+-0.0157973 s
GPU: 165.565 millions/s
______________________________________________
n=8388608 values in range: [0; 255]
CPU: 0.0946667+-0.000471405 s
CPU: 88.6121 millions/s
GPU: 0.0168333+-0.0255696 s
GPU: 498.333 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.1865+-0.000957427 s
CPU: 89.9583 millions/s
GPU: 0.00966667+-0.000471405 s
GPU: 1735.57 millions/s
</pre>
</p></details>

<details><summary>Github CI (prefix sum)</summary><p>
<pre>
Run ./prefix_sum
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
______________________________________________
n=2 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 2.1e-05+-0 s
GPU: 0.0952381 millions/s
______________________________________________
n=4 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 5.08333e-05+-1.86339e-06 s
GPU: 0.0786885 millions/s
______________________________________________
n=8 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 7.31667e-05+-4.09946e-06 s
GPU: 0.109339 millions/s
______________________________________________
n=16 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 8.68333e-05+-2.26691e-06 s
GPU: 0.184261 millions/s
______________________________________________
n=32 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 9.78333e-05+-8.97527e-07 s
GPU: 0.327087 millions/s
______________________________________________
n=64 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.0001155+-2.69258e-06 s
GPU: 0.554113 millions/s
______________________________________________
n=128 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000133167+-1.21335e-06 s
GPU: 0.961202 millions/s
______________________________________________
n=256 values in range: [0; 1023]
CPU: 5e-07+-5e-07 s
CPU: 512 millions/s
GPU: 0.000147+-3.16228e-06 s
GPU: 1.7415 millions/s
______________________________________________
n=512 values in range: [0; 1023]
CPU: 1e-06+-0 s
CPU: 512 millions/s
GPU: 0.0001745+-2.36291e-06 s
GPU: 2.9341 millions/s
______________________________________________
n=1024 values in range: [0; 1023]
CPU: 2e-06+-0 s
CPU: 512 millions/s
GPU: 0.000209833+-1.34371e-06 s
GPU: 4.88006 millions/s
______________________________________________
n=2048 values in range: [0; 1023]
CPU: 3.5e-06+-5e-07 s
CPU: 585.143 millions/s
GPU: 0.000249333+-1.97203e-06 s
GPU: 8.2139 millions/s
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 8e-06+-0 s
CPU: 512 millions/s
GPU: 0.000292333+-2.98142e-06 s
GPU: 14.0114 millions/s
______________________________________________
n=8192 values in range: [0; 1023]
CPU: 1.55e-05+-5e-07 s
CPU: 528.516 millions/s
GPU: 0.000301+-9.45163e-06 s
GPU: 27.2159 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 3.11667e-05+-3.72678e-07 s
CPU: 525.69 millions/s
GPU: 0.000404833+-2.26691e-06 s
GPU: 40.471 millions/s
______________________________________________
n=32768 values in range: [0; 1023]
CPU: 6.3e-05+-0 s
CPU: 520.127 millions/s
GPU: 0.000589167+-4.44763e-05 s
GPU: 55.6175 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000125333+-4.71405e-07 s
CPU: 522.894 millions/s
GPU: 0.000821333+-1.91978e-05 s
GPU: 79.7922 millions/s
______________________________________________
n=131072 values in range: [0; 1023]
CPU: 0.000250167+-3.72678e-07 s
CPU: 523.939 millions/s
GPU: 0.000991167+-6.12146e-06 s
GPU: 132.24 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000501667+-7.45356e-07 s
CPU: 522.546 millions/s
GPU: 0.0015615+-6.06156e-05 s
GPU: 167.88 millions/s
______________________________________________
n=524288 values in range: [0; 1023]
CPU: 0.0010085+-3.3541e-06 s
CPU: 519.869 millions/s
GPU: 0.00257367+-0.000207347 s
GPU: 203.712 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00201033+-4.34613e-06 s
CPU: 521.593 millions/s
GPU: 0.00466367+-5.68819e-05 s
GPU: 224.839 millions/s
______________________________________________
n=2097152 values in range: [0; 1023]
CPU: 0.00405617+-1.35206e-05 s
CPU: 517.028 millions/s
GPU: 0.00901567+-5.33e-05 s
GPU: 232.612 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0081175+-9.03235e-06 s
CPU: 516.699 millions/s
GPU: 0.0209882+-0.000415911 s
GPU: 199.841 millions/s
______________________________________________
n=8388608 values in range: [0; 255]
CPU: 0.016178+-4.79583e-06 s
CPU: 518.519 millions/s
GPU: 0.0473113+-0.000426235 s
GPU: 177.307 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0323433+-1.1771e-05 s
CPU: 518.723 millions/s
GPU: 0.100933+-0.000202145 s
GPU: 166.222 millions/s
</pre>
</p></details>

<details><summary>Локальный вывод (radix sort)</summary><p>
<pre>
C:\reps\GPGPUTasks\cmake-build-debug\radix.exe 2
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-10870H CPU @ 2.20GHz. Intel(R) Corporation. Total memory: 16215 Mb
  Device #1: GPU. Intel(R) UHD Graphics. Total memory: 6486 Mb
  Device #2: GPU. NVIDIA GeForce RTX 3080 Laptop GPU. Total memory: 8191 Mb
Using device #2: GPU. NVIDIA GeForce RTX 3080 Laptop GPU. Total memory: 8191 Mb
Data generated for n=33554432!
CPU: 17.1907+-0.204352 s
CPU: 1.91965 millions/s
GPU: 2.2155+-0.0328925 s
GPU: 14.8951 millions/s
</pre>
</p></details>

<details><summary>Github CI (radix sort)</summary><p>
<pre>
Run ./radix
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
Data generated for n=33554432!
CPU: 3.5797+-0.145072 s
CPU: 9.21865 millions/s
GPU: 18.8308+-0.0550078 s
GPU: 1.75245 millions/s
</pre>
</p></details>