### PR TITLE
Task06 Илья Эпельбаум ITMO

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,51 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define WORK_GROUP 256
+
+__kernel void bitonic_local(__global float *as, int n, int size, int interval) {
+    unsigned int i = get_global_id(0);
+    unsigned int local_i = get_local_id(0);
+    __local float local_as[WORK_GROUP];
+
+    if (i < n) {
+        local_as[local_i] = as[i];
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    unsigned int isChange = i % (2 * size) < size;
+    for (int shift = interval; shift > 0; shift /= 2) {
+        if (i + shift < n && i % (2 * shift) < shift) {
+            float a = local_as[local_i];
+            float b = local_as[local_i + shift];
+            if ((a > b) == isChange) {
+                local_as[local_i] = b;
+                local_as[local_i + shift] = a;
+            }
+        }
+
+      barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (i < n) {
+        as[i] = local_as[local_i];
+    }
+}
+
+__kernel void bitonic(__global float *as, int n, int size, int interval) {
+    unsigned int i = get_global_id(0);
+
+    bool isChange = i % (2 * size) < size;
+    if (i + interval < n && i % (2 * interval) < interval) {
+        float a = as[i];
+        float b = as[i + interval];
+        if ((a > b) == isChange) {
+            as[i] = b;
+            as[i + interval] = a;
+        }
+    }
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,27 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void prefix(__global unsigned int *as, __global unsigned int *bs, unsigned int n, unsigned int bit) {
+    unsigned int i = get_global_id(0);
+
+    if (i < n && (((i + 1) >> bit) & 1)) {
+        bs[i] += as[((i + 1) >> bit) - 1];
+    }
+}
+
+__kernel void reduce(__global unsigned int *as, __global unsigned int *bs, unsigned int n) {
+    unsigned int i = get_global_id(0);
+    if (i < n) {
+      bs[i] = as[2*i] + as[2*i + 1];
+    }
+}
+
+__kernel void zero(__global unsigned int *bs,  unsigned int n) {
+    unsigned int i = get_global_id(0);
+    if (i < n) {
+        bs[i] = 0;
+    }
+}

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
     context.init(device.device_id_opencl);
     context.activate();
 
-    int benchmarkingIters = 10;
+    int benchmarkingIters = 1;
     unsigned int n = 32 * 1024 * 1024;
     std::vector<float> as(n, 0);
     FastRandom r(n);
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -58,15 +58,27 @@ int main(int argc, char **argv) {
         ocl::Kernel bitonic(bitonic_kernel, bitonic_kernel_length, "bitonic");
         bitonic.compile();
 
+        ocl::Kernel bitonic_local(bitonic_kernel, bitonic_kernel_length, "bitonic_local");
+        bitonic_local.compile();
+
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             as_gpu.writeN(as.data(), n);
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            unsigned int workGroupSize = 128;
-            unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
-            bitonic.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, n);
+            unsigned int workGroupSize = 256;
+            int size = 1;
+            while (size < n) {
+              int interval = size;
+              size *= 2;
+              for (; interval > workGroupSize / 2; interval /= 2) {
+                bitonic.exec(gpu::WorkSize(workGroupSize, n), as_gpu, n, size, interval);
+              }
+
+              bitonic_local.exec(gpu::WorkSize(workGroupSize, n), as_gpu, n, size, interval);
+            }
+
             t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
@@ -79,6 +91,6 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }


### PR DESCRIPTION
<details><summary>Результат на сервере Github CI (prefix sum)</summary>
<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6950 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6950 Mb
______________________________________________
n=2 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 3.4e-05+-1.1547e-06 s
GPU: 0 millions/s
______________________________________________
n=4 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 4.96667e-05+-1.10554e-06 s
GPU: 0 millions/s
______________________________________________
n=8 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 6.48333e-05+-6.87184e-07 s
GPU: 0 millions/s
______________________________________________
n=16 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 8.25e-05+-2.36291e-06 s
GPU: 0 millions/s
______________________________________________
n=32 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 9.58333e-05+-1.46249e-06 s
GPU: 0 millions/s
______________________________________________
n=64 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000114+-1.82574e-06 s
GPU: 0 millions/s
______________________________________________
n=128 values in range: [0; 1023]
CPU: 3.33333e-07+-4.71405e-07 s
CPU: 384 millions/s
GPU: 0.000128833+-6.87184e-07 s
GPU: 0 millions/s
______________________________________________
n=256 values in range: [0; 1023]
CPU: 6.66667e-07+-4.71405e-07 s
CPU: 384 millions/s
GPU: 0.000152333+-2.35702e-06 s
GPU: 0 millions/s
______________________________________________
n=512 values in range: [0; 1023]
CPU: 1.16667e-06+-3.72678e-07 s
CPU: 438.857 millions/s
GPU: 0.000182167+-1.95078e-06 s
GPU: 0 millions/s
______________________________________________
n=1024 values in range: [0; 1023]
CPU: 3e-06+-0 s
CPU: 341.333 millions/s
GPU: 0.000219+-3.05505e-06 s
GPU: 0 millions/s
______________________________________________
n=2048 values in range: [0; 1023]
CPU: 5.33333e-06+-4.71405e-07 s
CPU: 384 millions/s
GPU: 0.000259333+-1.79505e-06 s
GPU: 0 millions/s
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 1.11667e-05+-1.21335e-06 s
CPU: 366.806 millions/s
GPU: 0.0003005+-2.36291e-06 s
GPU: 0 millions/s
______________________________________________
n=8192 values in range: [0; 1023]
CPU: 2.03333e-05+-4.71405e-07 s
CPU: 402.885 millions/s
GPU: 0.000367+-5.25991e-06 s
GPU: 0 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 4.5e-05+-3.91578e-06 s
CPU: 364.089 millions/s
GPU: 0.000473+-2.08167e-06 s
GPU: 0 millions/s
______________________________________________
n=32768 values in range: [0; 1023]
CPU: 8.48333e-05+-6.30916e-06 s
CPU: 386.263 millions/s
GPU: 0.000626667+-2.92499e-06 s
GPU: 0 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000193833+-1.99534e-05 s
CPU: 338.105 millions/s
GPU: 0.000787167+-3.71558e-06 s
GPU: 0 millions/s
______________________________________________
n=131072 values in range: [0; 1023]
CPU: 0.000354833+-2.60539e-05 s
CPU: 369.39 millions/s
GPU: 0.00112083+-6.36178e-06 s
GPU: 0 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000732+-4.58258e-06 s
CPU: 358.12 millions/s
GPU: 0.00174667+-4.18994e-06 s
GPU: 0 millions/s
______________________________________________
n=524288 values in range: [0; 1023]
CPU: 0.00152633+-4.86781e-05 s
CPU: 343.495 millions/s
GPU: 0.00302967+-5.93483e-06 s
GPU: 0 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00315817+-3.5807e-05 s
CPU: 332.02 millions/s
GPU: 0.00565183+-8.27479e-06 s
GPU: 176.934 millions/s
______________________________________________
n=2097152 values in range: [0; 1023]
CPU: 0.00575483+-2.58161e-05 s
CPU: 364.416 millions/s
GPU: 0.011077+-0.000120143 s
GPU: 180.554 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0120905+-0.000167256 s
CPU: 346.909 millions/s
GPU: 0.0221253+-7.14648e-05 s
GPU: 180.788 millions/s
______________________________________________
n=8388608 values in range: [0; 255]
CPU: 0.0206252+-2.90942e-05 s
CPU: 406.717 millions/s
GPU: 0.0466695+-0.000263401 s
GPU: 171.418 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0413283+-3.18573e-05 s
CPU: 405.949 millions/s
GPU: 0.104657+-0.000161558 s
GPU: 152.88 millions/s
</pre>
</details>

<details><summary>Результат на компьютере (prefix sum)</summary>
<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 5800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15724 Mb
  Device #1: GPU. AMD Radeon(TM) Graphics (gfx902). Free memory: 6148/6216 Mb
  Device #2: GPU. AMD Radeon(TM) Graphics (gfx902). Free memory: 6148/6216 Mb
Using device #1: GPU. AMD Radeon(TM) Graphics (gfx902). Free memory: 6148/6216 Mb
______________________________________________
n=2 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.0005+-0.0005 s
GPU: 0 millions/s
______________________________________________
n=4 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0 millions/s
______________________________________________
n=8 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0 millions/s
______________________________________________
n=16 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00133333+-0.000471405 s
GPU: 0 millions/s
______________________________________________
n=32 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.002+-0 s
GPU: 0 millions/s
______________________________________________
n=64 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.002+-0 s
GPU: 0 millions/s
______________________________________________
n=128 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00216667+-0.000372678 s
GPU: 0 millions/s
______________________________________________
n=256 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00216667+-0.000372678 s
GPU: 0 millions/s
______________________________________________
n=512 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00216667+-0.000372678 s
GPU: 0 millions/s
______________________________________________
n=1024 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.0025+-0.0005 s
GPU: 0 millions/s
______________________________________________
n=2048 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00283333+-0.000372678 s
GPU: 0 millions/s
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00333333+-0.000471405 s
GPU: 0 millions/s
______________________________________________
n=8192 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00333333+-0.000471405 s
GPU: 0 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00866667+-0.000471405 s
GPU: 0 millions/s
______________________________________________
n=32768 values in range: [0; 1023]
CPU: 0.001+-0 s
CPU: 32.768 millions/s
GPU: 0.00466667+-0.000942809 s
GPU: 0 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.001+-0 s
CPU: 65.536 millions/s
GPU: 0.0045+-0.0005 s
GPU: 0 millions/s
______________________________________________
n=131072 values in range: [0; 1023]
CPU: 0.002+-0 s
CPU: 65.536 millions/s
GPU: 0.00516667+-0.000372678 s
GPU: 0 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.004+-0 s
CPU: 65.536 millions/s
GPU: 0.00716667+-0.000372678 s
GPU: 0 millions/s
______________________________________________
n=524288 values in range: [0; 1023]
CPU: 0.007+-0 s
CPU: 74.8983 millions/s
GPU: 0.00583333+-0.000372678 s
GPU: 0 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0116667+-0.000471405 s
CPU: 89.8779 millions/s
GPU: 0.00883333+-0.000372678 s
GPU: 113.208 millions/s
______________________________________________
n=2097152 values in range: [0; 1023]
CPU: 0.0233333+-0.000471405 s
CPU: 89.8779 millions/s
GPU: 0.021+-0.001 s
GPU: 95.2381 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0463333+-0.000471405 s
CPU: 90.5245 millions/s
GPU: 0.0315+-0.000763763 s
GPU: 126.984 millions/s
______________________________________________
n=8388608 values in range: [0; 255]
CPU: 0.0933333+-0.000471405 s
CPU: 89.8779 millions/s
GPU: 0.065+-0.000816497 s
GPU: 123.077 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.185667+-0.000745356 s
CPU: 90.362 millions/s
GPU: 0.144167+-0.0157207 s
GPU: 110.983 millions/s
</pre>
</details>

<details><summary>Результат на сервере Github CI (bitonic)</summary>
<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
Data generated for n=33554432!
CPU: 4.07404+-0 s
CPU: 8.10007 millions/s
GPU: 8.40371+-0 s
GPU: 3.92684 millions/s
</pre>
</details>

<details><summary>Результат на компьютере (bitonic)</summary>
<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 5800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15724 Mb
  Device #1: GPU. AMD Radeon(TM) Graphics (gfx902). Free memory: 6148/6216 Mb
  Device #2: GPU. AMD Radeon(TM) Graphics (gfx902). Free memory: 6148/6216 Mb
Using device #1: GPU. AMD Radeon(TM) Graphics (gfx902). Free memory: 6148/6216 Mb
Data generated for n=33554432!
CPU: 18.988+-0 s
CPU: 1.73794 millions/s
GPU: 1.898+-0 s
GPU: 17.3867 millions/s
</pre>
</details>