### PR TITLE
Task06 Владимир Рачкин SPbU

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -4,33 +4,82 @@
 
 #line 6
 
-void swap_global(__global float* a, __global float* b) {
-    unsigned int tmp = *a;
+__kernel void swap_global(__global float* a, __global float* b) {
+    float tmp = *a;
     *a = *b;
     *b = tmp;
 }
 
-void sort_global(__global float* a, __global float* b) {
+__kernel void sort_global(__global float* a, __global float* b) {
     if (*a > *b)
         swap_global(a, b);
 }
 
-void rev_sort_global(__global float* a, __global float* b) {
+__kernel void rev_sort_global(__global float* a, __global float* b) {
     if (*a < *b)
         swap_global(a, b);
 }
 
-__kernel void bitonic_big_segment(__global float *as, unsigned int segment_size, unsigned int size, bool reversable, unsigned int n) {
+__kernel void bitonic_big_segment(__global float *as, unsigned int segment_size, unsigned int size, unsigned int n) {
     const unsigned int index = get_global_id(0);
-    if (index >= n)
+    if (index % size >= size / 2)
         return;
 
-    const unsigned int i1 = index % (size / 2) + size * (index / size * 2);
+    const unsigned int i1 = index % (size / 2) + size * (index / size);
     const unsigned int i2 = i1 + size/2;
 
     bool order = i1 / segment_size % 2;
 
-    if (order)
+    if (!order) {
+        sort_global(&as[i1], &as[i2]);
+    } else {
+        rev_sort_global(&as[i1], &as[i2]);
+    }
+}
+
+__kernel void swap_local(__local float* a, __local float* b) {
+    float tmp = *a;
+    *a = *b;
+    *b = tmp;
+}
+
+__kernel void sort_local(__local float* a, __local float* b) {
+    if (*a > *b)
+        swap_local(a, b);
+}
+
+__kernel void rev_sort_local(__local float* a, __local float* b) {
+    if (*a < *b)
+        swap_local(a, b);
+}
+
+#define MAX_LOCAL_SEGMENT_SIZE 128
+__kernel void bitonic_small_segment(__global float *as, unsigned int segment_size, unsigned int n) {
+    const unsigned int index = get_global_id(0);
+    const unsigned int local_index = get_local_id(0);
+    if (index >= n)
+        return;
+
+    __local float tmp[MAX_LOCAL_SEGMENT_SIZE];
+    tmp[local_index] = as[index];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    bool order = (index / segment_size) % 2;
 
 
+    for (unsigned int size = segment_size; size >= 2; size /= 2) {
+        if (local_index % size < size / 2) {
+            const unsigned int i1 = local_index % (size / 2) + size * (local_index / size);
+            const unsigned int i2 = i1 + size / 2;
+            if (!order) {
+                sort_local(&tmp[i1], &tmp[i2]);
+            } else {
+                rev_sort_local(&tmp[i1], &tmp[i2]);
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    as[index] = tmp[local_index];
 }

--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,36 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+void swap_global(__global float* a, __global float* b) {
+    unsigned int tmp = *a;
+    *a = *b;
+    *b = tmp;
+}
+
+void sort_global(__global float* a, __global float* b) {
+    if (*a > *b)
+        swap_global(a, b);
+}
+
+void rev_sort_global(__global float* a, __global float* b) {
+    if (*a < *b)
+        swap_global(a, b);
+}
+
+__kernel void bitonic_big_segment(__global float *as, unsigned int segment_size, unsigned int size, bool reversable, unsigned int n) {
+    const unsigned int index = get_global_id(0);
+    if (index >= n)
+        return;
+
+    const unsigned int i1 = index % (size / 2) + size * (index / size * 2);
+    const unsigned int i2 = i1 + size/2;
+
+    bool order = i1 / segment_size % 2;
+
+    if (order)
+
+
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -16,7 +16,6 @@ __kernel void prefix_sum(__global const unsigned int* a,
     if (((index+1)>>level) & 1) {
         b[index] += a[((index+1)>>level) - 1];
     }
-
 }
 
 __kernel void prefix_sum_other(__global const unsigned int* a,

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,31 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void prefix_sum(__global const unsigned int* a,
+                     __global unsigned int* b,
+                     unsigned int n,
+                     unsigned int level)
+{
+    const unsigned int index = get_global_id(0);
+    if (index >= n)
+        return;
+
+    if (((index+1)>>level) & 1) {
+        b[index] += a[((index+1)>>level) - 1];
+    }
+
+}
+
+__kernel void prefix_sum_other(__global const unsigned int* a,
+                             __global unsigned int* c,
+                             unsigned int n)
+{
+    const unsigned int index = get_global_id(0);
+    if (index >= n)
+        return;
+
+    c[index] = a[2 * index] + a[2 * index + 1];
+}

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -1,3 +1,110 @@
-__kernel void radix(__global unsigned int *as) {
-    // TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define SEGMENT_SIZE 128
+
+
+__kernel void radix_counters(__global const unsigned int *as, __global unsigned int *counters, unsigned int offset, unsigned int n) {
+    const unsigned int id = get_global_id(0);
+    if (id * SEGMENT_SIZE >= n)
+        return;
+
+    unsigned int segment_begin = id * SEGMENT_SIZE;
+    unsigned int segment_end = (id + 1) * SEGMENT_SIZE;
+
+    unsigned int counter = 0;
+
+    for (int i = segment_begin; i < segment_end; i++) {
+        counter += (as[i] >> offset) & 1;
+    }
+
+    counters[id] = counter;
+}
+
+
+__kernel void prefix_sum_reduce(__global const unsigned int* a,
+                         __global unsigned int* b,
+                         unsigned int n,
+                         unsigned int level)
+{
+    const unsigned int index = get_global_id(0);
+    if (index >= n)
+        return;
+
+    if (((index+1)>>level) & 1) {
+        b[index] += a[((index+1)>>level) - 1];
+    }
+
+}
+
+
+__kernel void prefix_sum_gather(__global const unsigned int* a,
+                               __global unsigned int* c,
+                               unsigned int n)
+{
+    const unsigned int index = get_global_id(0);
+    if (index >= n)
+        return;
+
+    c[index] = a[2 * index] + a[2 * index + 1];
+}
+
+
+__kernel void local_sort(__local unsigned int *tmp, __local unsigned int *counter, unsigned int offset) {
+    unsigned int tmp_counter = 0;
+    unsigned int tmp2[SEGMENT_SIZE];
+    for (unsigned int i = 0; i < SEGMENT_SIZE; i++) {
+        tmp2[i] = tmp[i];
+        tmp_counter += ((tmp2[i] >> offset) & 1);
+    }
+
+    unsigned int i = 0, j = SEGMENT_SIZE - tmp_counter;
+    for (unsigned int k = 0; k < SEGMENT_SIZE; k++) {
+        if (!((tmp2[k] >> offset) & 1))
+            tmp[i++] = tmp2[k];
+        else
+            tmp[j++] = tmp2[k];
+    }
+
+    *counter = tmp_counter;
+}
+
+
+__kernel void radix_sort(__global const unsigned int *counters, __global unsigned int *as, unsigned int offset, unsigned int n) {
+    const unsigned int id = get_global_id(0);
+    const unsigned int group_id = get_group_id(0);
+    const unsigned int local_id = get_local_id(0);
+    if (id >= n)
+        return;
+
+    unsigned int zero_all_count = n - counters[n / SEGMENT_SIZE - 1];
+
+    __local unsigned int counter_sum;
+    __local unsigned int counter;
+    __local unsigned int tmp[SEGMENT_SIZE];
+    tmp[local_id] = as[id];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (id == group_id * SEGMENT_SIZE) {
+        if (group_id == 0)
+            counter_sum = 0;
+        else
+            counter_sum = counters[group_id-1];
+
+        local_sort(tmp, &counter, offset);
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    unsigned int zero_counter = SEGMENT_SIZE - counter;
+    unsigned int zero_counter_sum = group_id * SEGMENT_SIZE - counter_sum;
+
+
+    unsigned int new_pos = (local_id < zero_counter
+            ? zero_counter_sum + local_id
+            : zero_all_count + counter_sum + (local_id - zero_counter));
+    as[new_pos] = tmp[local_id];
+
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -22,6 +22,20 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 int main(int argc, char **argv)
 {
+    // chooseGPUDevice:
+    // - Если не доступо ни одного устройства - кинет ошибку
+    // - Если доступно ровно одно устройство - вернет это устройство
+    // - Если доступно N>1 устройства:
+    //   - Если аргументов запуска нет или переданное число не находится в диапазоне от 0 до N-1 - кинет ошибку
+    //   - Если аргумент запуска есть и он от 0 до N-1 - вернет устройство под указанным номером
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+    // Этот контекст после активации будет прозрачно использоваться при всех вызовах в libgpu библиотеке
+    // это достигается использованием thread-local переменных, т.е. на самом деле контекст будет активирован для текущего потока исполнения
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
 	int benchmarkingIters = 10;
 	unsigned int max_n = (1 << 24);
 
@@ -77,7 +91,45 @@ int main(int argc, char **argv)
 		}
 
 		{
-			// TODO: implement on OpenCL
+            bs.assign(n, 0);
+            gpu::gpu_mem_32u as_gpu, bs_gpu, cs_gpu;
+            as_gpu.resizeN(n);
+            bs_gpu.resizeN(n);
+            cs_gpu.resizeN(n);
+
+            ocl::Kernel prefix_sum_bin(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum");
+            prefix_sum_bin.compile();
+            ocl::Kernel prefix_sum_other(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_other");
+            prefix_sum_other.compile();
+
+            unsigned int workGroupSize = 128;
+            unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                as_gpu.writeN(as.data(), n);
+                bs_gpu.writeN(bs.data(), n);
+
+                for (unsigned int level = 0; (1<<level) <= n; level++) {
+                    prefix_sum_bin.exec(gpu::WorkSize(workGroupSize, global_work_size),
+                                        as_gpu, bs_gpu, n, level);
+                    prefix_sum_other.exec(gpu::WorkSize(workGroupSize, global_work_size),
+                                          as_gpu, cs_gpu, n / (1<<(level+1)));
+                    as_gpu.swap(cs_gpu);
+                }
+
+                t.nextLap();
+            }
+
+            bs_gpu.readN(bs.data(), n);
+
+            for (int i = 0; i < n; ++i) {
+                EXPECT_THE_SAME(bs[i], reference_result[i], "GPU results should be equal to CPU results!");
+            }
+
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+
 		}
 	}
 }


### PR DESCRIPTION
<details><summary>Локальный вывод (Prefix sum)</summary><p>

<pre>
/home/vladimir/CLionProjects/GPGPUTasks2022/cmake-build-debug/prefix_sum 2
OpenCL devices:
  Device #0: GPU. AMD RENOIR (LLVM 14.0.6, DRM 3.42, 5.15.74-3-MANJARO). Total memory: 3072 Mb
  Device #1: CPU. AMD Ryzen 7 4700U with Radeon Graphics         . Intel(R) Corporation. Total memory: 15413 Mb
  Device #2: GPU. NVIDIA GeForce MX350. Total memory: 2002 Mb
Using device #2: GPU. NVIDIA GeForce MX350. Total memory: 2002 Mb
______________________________________________
n=2 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 3.1e-05+-0 s
GPU: 0.0645161 millions/s
______________________________________________
n=4 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 5.2e-05+-0 s
GPU: 0.0769231 millions/s
______________________________________________
n=8 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 7.78333e-05+-6.2026e-06 s
GPU: 0.102784 millions/s
______________________________________________
n=16 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 9.4e-05+-0 s
GPU: 0.170213 millions/s
______________________________________________
n=32 values in range: [0; 1023]
CPU: 3.33333e-07+-4.71405e-07 s
CPU: 96 millions/s
GPU: 0.000115+-5.7735e-07 s
GPU: 0.278261 millions/s
______________________________________________
n=64 values in range: [0; 1023]
CPU: 6.66667e-07+-4.71405e-07 s
CPU: 96 millions/s
GPU: 0.0001365+-2.06155e-06 s
GPU: 0.468864 millions/s
______________________________________________
n=128 values in range: [0; 1023]
CPU: 1e-06+-0 s
CPU: 128 millions/s
GPU: 0.0001575+-2.14087e-06 s
GPU: 0.812698 millions/s
______________________________________________
n=256 values in range: [0; 1023]
CPU: 1.33333e-06+-4.71405e-07 s
CPU: 192 millions/s
GPU: 0.000177167+-3.72678e-07 s
GPU: 1.44497 millions/s
______________________________________________
n=512 values in range: [0; 1023]
CPU: 3.16667e-06+-3.72678e-07 s
CPU: 161.684 millions/s
GPU: 0.000198667+-7.45356e-07 s
GPU: 2.57718 millions/s
______________________________________________
n=1024 values in range: [0; 1023]
CPU: 6e-06+-0 s
CPU: 170.667 millions/s
GPU: 0.000219+-8.16497e-07 s
GPU: 4.6758 millions/s
______________________________________________
n=2048 values in range: [0; 1023]
CPU: 1.28333e-05+-6.87184e-07 s
CPU: 159.584 millions/s
GPU: 0.000242167+-1.06719e-06 s
GPU: 8.45699 millions/s
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.36667e-05+-4.71405e-07 s
CPU: 173.07 millions/s
GPU: 0.000264333+-9.42809e-07 s
GPU: 15.4956 millions/s
______________________________________________
n=8192 values in range: [0; 1023]
CPU: 4.71667e-05+-3.72678e-07 s
CPU: 173.682 millions/s
GPU: 0.0002905+-2.14087e-06 s
GPU: 28.1997 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 9.4e-05+-0 s
CPU: 174.298 millions/s
GPU: 0.000324167+-1.21335e-06 s
GPU: 50.5419 millions/s
______________________________________________
n=32768 values in range: [0; 1023]
CPU: 0.0001895+-5e-07 s
CPU: 172.918 millions/s
GPU: 0.000365333+-3.03681e-06 s
GPU: 89.6934 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000385667+-6.2361e-06 s
CPU: 169.929 millions/s
GPU: 0.000436167+-2.54406e-06 s
GPU: 150.254 millions/s
______________________________________________
n=131072 values in range: [0; 1023]
CPU: 0.000787833+-8.43439e-06 s
CPU: 166.37 millions/s
GPU: 0.000655833+-6.33553e-06 s
GPU: 199.856 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.0016585+-3.86512e-05 s
CPU: 158.061 millions/s
GPU: 0.00103367+-6.99206e-06 s
GPU: 253.606 millions/s
______________________________________________
n=524288 values in range: [0; 1023]
CPU: 0.00332117+-2.01777e-05 s
CPU: 157.863 millions/s
GPU: 0.0017745+-5.43906e-06 s
GPU: 295.457 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00653867+-2.25807e-05 s
CPU: 160.365 millions/s
GPU: 0.00321633+-2.13437e-06 s
GPU: 326.016 millions/s
______________________________________________
n=2097152 values in range: [0; 1023]
CPU: 0.0129813+-3.57942e-05 s
CPU: 161.551 millions/s
GPU: 0.00600217+-4.56131e-06 s
GPU: 349.399 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0259972+-7.67538e-05 s
CPU: 161.337 millions/s
GPU: 0.0118473+-3.59243e-05 s
GPU: 354.029 millions/s
______________________________________________
n=8388608 values in range: [0; 255]
CPU: 0.0527557+-0.000303227 s
CPU: 159.009 millions/s
GPU: 0.0239137+-1.79041e-05 s
GPU: 350.787 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.105703+-0.000152159 s
CPU: 158.72 millions/s
GPU: 0.0489035+-7.08872e-06 s
GPU: 343.068 millions/s

Process finished with exit code 0


</pre>

</p></details>


<details><summary>Вывод Travis CI (Prefix sum) </summary><p>

<pre>
Run ./prefix_sum
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
______________________________________________
n=2 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 2.7e-05+-8.16497e-07 s
GPU: 0.0740741 millions/s
______________________________________________
n=4 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 4.73333e-05+-9.42809e-07 s
GPU: 0.084507 millions/s
______________________________________________
n=8 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 6.83333e-05+-2.21108e-06 s
GPU: 0.117073 millions/s
______________________________________________
n=16 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 8.4e-05+-1.1547e-06 s
GPU: 0.190476 millions/s
______________________________________________
n=32 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000102+-8.16497e-07 s
GPU: 0.313725 millions/s
______________________________________________
n=64 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000137333+-0.000112176 s
GPU: 0.466019 millions/s
______________________________________________
n=128 values in range: [0; 1023]
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 768 millions/s
GPU: 9.71667e-05+-1.46249e-06 s
GPU: 1.31732 millions/s
______________________________________________
n=256 values in range: [0; 1023]
CPU: 5e-07+-5e-07 s
CPU: 512 millions/s
GPU: 0.000112833+-1.46249e-06 s
GPU: 2.26883 millions/s
______________________________________________
n=512 values in range: [0; 1023]
CPU: 1e-06+-0 s
CPU: 512 millions/s
GPU: 0.000193+-2.94392e-06 s
GPU: 2.65285 millions/s
______________________________________________
n=1024 values in range: [0; 1023]
CPU: 2e-06+-0 s
CPU: 512 millions/s
GPU: 0.000225667+-1.24722e-06 s
GPU: 4.53767 millions/s
______________________________________________
n=2048 values in range: [0; 1023]
CPU: 4e-06+-0 s
CPU: 512 millions/s
GPU: 0.000256+-2.44949e-06 s
GPU: 8 millions/s
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 8e-06+-0 s
CPU: 512 millions/s
GPU: 0.000298167+-6.84146e-06 s
GPU: 13.7373 millions/s
______________________________________________
n=8192 values in range: [0; 1023]
CPU: 1.55e-05+-5e-07 s
CPU: 528.516 millions/s
GPU: 0.000351833+-2.79384e-06 s
GPU: 23.2838 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 3.11667e-05+-3.72678e-07 s
CPU: 525.69 millions/s
GPU: 0.0004405+-1.98725e-05 s
GPU: 37.1941 millions/s
______________________________________________
n=32768 values in range: [0; 1023]
CPU: 6.28333e-05+-3.72678e-07 s
CPU: 521.507 millions/s
GPU: 0.000562667+-7.45356e-07 s
GPU: 58.237 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000125+-0 s
CPU: 524.288 millions/s
GPU: 0.000667833+-5.63964e-06 s
GPU: 98.1323 millions/s
______________________________________________
n=131072 values in range: [0; 1023]
CPU: 0.000250667+-4.71405e-07 s
CPU: 522.894 millions/s
GPU: 0.000951833+-3.80457e-05 s
GPU: 137.705 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000501+-0 s
CPU: 523.242 millions/s
GPU: 0.001612+-3.19009e-05 s
GPU: 162.62 millions/s
______________________________________________
n=524288 values in range: [0; 1023]
CPU: 0.0010025+-1.5e-06 s
CPU: 522.981 millions/s
GPU: 0.00242767+-4.18994e-06 s
GPU: 215.964 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00201167+-5.99073e-06 s
CPU: 521.247 millions/s
GPU: 0.004539+-1.16046e-05 s
GPU: 231.015 millions/s
______________________________________________
n=2097152 values in range: [0; 1023]
CPU: 0.004017+-2.3094e-06 s
CPU: 522.069 millions/s
GPU: 0.00887517+-3.66125e-05 s
GPU: 236.294 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00805933+-5.4365e-06 s
CPU: 520.428 millions/s
GPU: 0.0184425+-0.000125414 s
GPU: 227.426 millions/s
______________________________________________
n=8388608 values in range: [0; 255]
CPU: 0.0161168+-3.3375e-06 s
CPU: 520.487 millions/s
GPU: 0.0451533+-0.000368414 s
GPU: 185.78 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.032219+-2.88675e-06 s
CPU: 520.724 millions/s
GPU: 0.0992628+-0.000366831 s
GPU: 169.018 millions/s
</pre>

</p></details>


<details><summary>Локальный вывод (Bitonic sort)</summary><p>

<pre>
/home/vladimir/CLionProjects/GPGPUTasks2022/cmake-build-debug/bitonic 2
OpenCL devices:
  Device #0: GPU. AMD RENOIR (LLVM 14.0.6, DRM 3.42, 5.15.74-3-MANJARO). Total memory: 3072 Mb
  Device #1: CPU. AMD Ryzen 7 4700U with Radeon Graphics         . Intel(R) Corporation. Total memory: 15413 Mb
  Device #2: GPU. NVIDIA GeForce MX350. Total memory: 2002 Mb
Using device #2: GPU. NVIDIA GeForce MX350. Total memory: 2002 Mb
Data generated for n=33554432!
CPU: 12.7495+-0.0599623 s
CPU: 2.58833 millions/s
GPU: 1.79933+-0.00367387 s
GPU: 18.3402 millions/s

Process finished with exit code 0

</pre>

</p></details>

<details><summary>Вывод Travis CI (Bitonic sort) </summary><p>

<pre>

</pre>

</p></details>


<details><summary>Локальный вывод (Radix sort)</summary><p>

<pre>
/home/vladimir/CLionProjects/GPGPUTasks2022/cmake-build-debug/radix 2
OpenCL devices:
  Device #0: GPU. AMD RENOIR (LLVM 14.0.6, DRM 3.42, 5.15.74-3-MANJARO). Total memory: 3072 Mb
  Device #1: CPU. AMD Ryzen 7 4700U with Radeon Graphics         . Intel(R) Corporation. Total memory: 15413 Mb
  Device #2: GPU. NVIDIA GeForce MX350. Total memory: 2002 Mb
Using device #2: GPU. NVIDIA GeForce MX350. Total memory: 2002 Mb
Data generated for n=33554432!
CPU: 4.74906+-0.123672 s
CPU: 6.94874 millions/s
GPU: 2.74545+-0 s
GPU: 12.0199 millions/s

Process finished with exit code 0

</pre>

</p></details>

<details><summary>Вывод Travis CI (Radix sort) </summary><p>

<pre>

Run ./radix
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6950 Mb
Data generated for n=33554432!
CPU: 3.23818+-0.000704433 s
CPU: 10.1909 millions/s
GPU: 19.2954+-0 s
GPU: 1.71025 millions/s
</pre>

</p></details>
